### PR TITLE
remove AudioPipeline base class

### DIFF
--- a/esphome/components/adf_pipeline/adf_audio_element.h
+++ b/esphome/components/adf_pipeline/adf_audio_element.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #ifdef USE_ESP_IDF
-#include "esphome/core/component.h"
 #include "esphome/core/log.h"
 
 #include <audio_element.h>
@@ -20,16 +19,15 @@ typedef struct {
 
 enum class PipelineElementState : uint8_t { UNAVAILABLE = 0, PREPARING, WAIT_FOR_PREPARATION_DONE, READY };
 
-class AudioPipeline;
 class ADFPipeline;
-class AudioPipelineElement;
+class ADFPipelineElement;
 
 enum AudioPipelineElementType : uint8_t { AUDIO_PIPELINE_SOURCE = 0, AUDIO_PIPELINE_SINK, AUDIO_PIPELINE_TRANSFORM };
 
 class AudioPipelineSettingsRequest {
  public:
   AudioPipelineSettingsRequest() = default;
-  AudioPipelineSettingsRequest(AudioPipelineElement *sender) : requested_by(sender) {}
+  AudioPipelineSettingsRequest(ADFPipelineElement *sender) : requested_by(sender) {}
   int sampling_rate{-1};
   int bit_depth{-1};
   int number_of_channels{-1};
@@ -38,26 +36,25 @@ class AudioPipelineSettingsRequest {
 
   bool failed{false};
   int error_code{0};
-  AudioPipelineElement *requested_by{nullptr};
-  AudioPipelineElement *failed_by{nullptr};
-};
-
-class AudioPipelineElement {
- public:
-  virtual ~AudioPipelineElement() {}
-  virtual AudioPipelineElementType get_element_type() const = 0;
-  virtual const std::string get_name() = 0;
-
-  virtual void on_pipeline_status_change() {}
-  virtual void on_settings_request(AudioPipelineSettingsRequest &request) {}
+  ADFPipelineElement *requested_by{nullptr};
+  ADFPipelineElement *failed_by{nullptr};
 };
 
 /*
 Represents and manages one or more ADF-SDK audio elements which form a logical unit.
 e.g. HttpStreamer and Decoder, re-sampler and stream_writer
 */
-class ADFPipelineElement : public AudioPipelineElement {
+class ADFPipelineElement {
  public:
+  virtual ~ADFPipelineElement() {}
+
+  virtual AudioPipelineElementType get_element_type() const = 0;
+  virtual const std::string get_name() = 0;
+
+  virtual void on_pipeline_status_change() {}
+  virtual void on_settings_request(AudioPipelineSettingsRequest &request) {}
+
+
   std::vector<audio_element_handle_t> get_adf_elements() { return sdk_audio_elements_; }
   std::string get_adf_element_tag(int element_indx);
   void init_adf_elements() { init_adf_elements_(); }

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
@@ -1,7 +1,5 @@
 #include "adf_media_player.h"
 #include "esphome/core/log.h"
-#include "mp3_decoder.h"
-#include <filter_resample.h>
 
 #ifdef USE_ESP_IDF
 
@@ -12,7 +10,6 @@ static const char *const TAG = "adf_audio";
 
 void ADFMediaPlayer::setup() {
   state = media_player::MEDIA_PLAYER_STATE_IDLE;
-  pipeline.init();
 }
 
 void ADFMediaPlayer::dump_config() {
@@ -48,7 +45,8 @@ void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
       case media_player::MEDIA_PLAYER_COMMAND_PLAY:
         state = media_player::MEDIA_PLAYER_STATE_PLAYING;
         if (pipeline.getState() == PipelineState::STOPPED || pipeline.getState() == PipelineState::UNAVAILABLE) {
-          this->start();
+          pipeline.init();
+          pipeline.start();
         } else if (pipeline.getState() == PipelineState::PAUSED) {
           pipeline.resume();
         }
@@ -60,7 +58,7 @@ void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         }
         break;
       case media_player::MEDIA_PLAYER_COMMAND_STOP:
-        this->stop();
+        pipeline.stop();
         break;
       case media_player::MEDIA_PLAYER_COMMAND_MUTE:
         this->mute_();
@@ -101,6 +99,7 @@ media_player::MediaPlayerTraits ADFMediaPlayer::get_traits() {
   traits.set_supports_pause(true);
   return traits;
 };
+
 
 void ADFMediaPlayer::mute_() {
   AudioPipelineSettingsRequest request;

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -3,21 +3,9 @@
 #ifdef USE_ESP_IDF
 
 #include "esphome/components/media_player/media_player.h"
-#include "esphome/core/component.h"
-#include "esphome/core/gpio.h"
-#include "esphome/core/helpers.h"
-
-// #include "../adf_audio_element.h"
-#include "../adf_pipeline.h"
 #include "../adf_audio_sources.h"
+#include "../adf_pipeline.h"
 
-#include "audio_pipeline.h"
-#include "audio_element.h"
-#include "audio_event_iface.h"
-#include "audio_common.h"
-#include "http_stream.h"
-
-#include <raw_stream.h>
 
 namespace esphome {
 namespace esp_adf {

--- a/esphome/components/adf_pipeline/microphone/esp_adf_microphone.cpp
+++ b/esphome/components/adf_pipeline/microphone/esp_adf_microphone.cpp
@@ -49,6 +49,7 @@ void ADFMicrophone::on_pipeline_state_change(PipelineState state) {
     case PipelineState::PAUSING:
     case PipelineState::RESUMING:
     case PipelineState::PREPARING:
+    case PipelineState::DESTROYING:
       break;
   }
 }

--- a/esphome/components/adf_pipeline/speaker/esp_adf_speaker.cpp
+++ b/esphome/components/adf_pipeline/speaker/esp_adf_speaker.cpp
@@ -51,6 +51,7 @@ void ADFSpeaker::on_pipeline_state_change(PipelineState state) {
       case PipelineState::PAUSING:
       case PipelineState::RESUMING:
       case PipelineState::PREPARING:
+      case PipelineState::DESTROYING:
         break;
 
    }


### PR DESCRIPTION
It was intended to support different audio libraries not just esp-adf.
Hence, the ADFPipeline was derived from a general AudioPipeline base class.
As I am not planing to add any other library in the near future, I removed the base class.
