### PR TITLE
Multiple Audio Formats and m3u (Playlist) files

### DIFF
--- a/esphome/components/adf_pipeline/adf_audio_sources.cpp
+++ b/esphome/components/adf_pipeline/adf_audio_sources.cpp
@@ -25,7 +25,7 @@ bool HTTPStreamReaderAndDecoder::init_adf_elements_() {
 
   http_stream_cfg_t http_cfg = HTTP_STREAM_CFG_DEFAULT();
   //http_cfg.task_core = 0;
-  http_cfg.out_rb_size = 500 * 1024;
+  http_cfg.out_rb_size = 50 * 1024;
   http_stream_reader_ = http_stream_init(&http_cfg);
   //http_stream_reader_->buf_size =  1024;
   audio_element_set_uri(this->http_stream_reader_, this->current_url_.c_str());
@@ -46,7 +46,7 @@ bool HTTPStreamReaderAndDecoder::init_adf_elements_() {
         DEFAULT_ESP_TS_DECODER_CONFIG(),
   };
   esp_decoder_cfg_t auto_dec_cfg = DEFAULT_ESP_DECODER_CONFIG();
-  auto_dec_cfg.out_rb_size = 500 * 1024;
+  auto_dec_cfg.out_rb_size = 50 * 1024;
   decoder_ = esp_decoder_init(&auto_dec_cfg, auto_decode, 10);
   
   sdk_audio_elements_.push_back(this->decoder_);

--- a/esphome/components/adf_pipeline/adf_audio_sources.cpp
+++ b/esphome/components/adf_pipeline/adf_audio_sources.cpp
@@ -3,15 +3,8 @@
 #ifdef USE_ESP_IDF
 
 #include <http_stream.h>
-#include <aac_decoder.h>
-#include <amr_decoder.h>
-#include <flac_decoder.h>
-#include <mp3_decoder.h>
-#include <ogg_decoder.h>
-#include <opus_decoder.h>
-#include <wav_decoder.h>
-
 #include <raw_stream.h>
+#include <esp_decoder.h>
 
 #include "sdk_ext.h"
 
@@ -39,49 +32,22 @@ bool HTTPStreamReaderAndDecoder::init_adf_elements_() {
   sdk_audio_elements_.push_back(this->http_stream_reader_);
   sdk_element_tags_.push_back("http");
 
-  if (this->decoder_type == ADFEncoding::AAC) {
-    esph_log_d(TAG, "decoder type: AAC" );
-    aac_decoder_cfg_t aac_cfg = DEFAULT_AAC_DECODER_CONFIG();
-    aac_cfg.out_rb_size = 4 * 1024;
-    decoder_ = aac_decoder_init(&aac_cfg);
-  }
-  else if (this->decoder_type == ADFEncoding::AMR) {
-    esph_log_d(TAG, "decoder type: AMR" );
-    amr_decoder_cfg_t amr_cfg = DEFAULT_AMR_DECODER_CONFIG();
-    amr_cfg.out_rb_size = 4 * 1024;
-    decoder_ = amr_decoder_init(&amr_cfg);
-  }
-  else if (this->decoder_type == ADFEncoding::FLAC) {
-    esph_log_d(TAG, "decoder type: FLAC" );
-    flac_decoder_cfg_t flac_cfg = DEFAULT_FLAC_DECODER_CONFIG();
-    flac_cfg.out_rb_size = 500 * 1024;
-    decoder_ = flac_decoder_init(&flac_cfg);
-  }
-  else if (this->decoder_type == ADFEncoding::MP3) {
-    esph_log_d(TAG, "decoder type: MP3" );
-    mp3_decoder_cfg_t mp3_cfg = DEFAULT_MP3_DECODER_CONFIG();
-    mp3_cfg.out_rb_size = 4 * 1024;
-    decoder_ = mp3_decoder_init(&mp3_cfg);
-  }
-  else if (this->decoder_type == ADFEncoding::OGG) {
-    esph_log_d(TAG, "decoder type: OGG" );
-    ogg_decoder_cfg_t ogg_cfg = DEFAULT_OGG_DECODER_CONFIG();
-    ogg_cfg.out_rb_size = 4 * 1024;
-    decoder_ = ogg_decoder_init(&ogg_cfg);
-  }
-  else if (this->decoder_type == ADFEncoding::OPUS) {
-    esph_log_d(TAG, "decoder type: OPUS" );
-    opus_decoder_cfg_t opus_cfg = DEFAULT_OPUS_DECODER_CONFIG();
-    opus_cfg.out_rb_size = 4 * 1024;
-    decoder_ = decoder_opus_init(&opus_cfg);
-  }
-  else {
-    esph_log_d(TAG, "decoder type: WAV" );
-    wav_decoder_cfg_t wav_cfg = DEFAULT_WAV_DECODER_CONFIG();
-    wav_cfg.out_rb_size = 4 * 1024;
-    decoder_ = wav_decoder_init(&wav_cfg);
-  }
-
+  audio_decoder_t auto_decode[] = {
+        DEFAULT_ESP_AMRNB_DECODER_CONFIG(),
+        DEFAULT_ESP_AMRWB_DECODER_CONFIG(),
+        DEFAULT_ESP_FLAC_DECODER_CONFIG(),
+        DEFAULT_ESP_OGG_DECODER_CONFIG(),
+        DEFAULT_ESP_OPUS_DECODER_CONFIG(),
+        DEFAULT_ESP_MP3_DECODER_CONFIG(),
+        DEFAULT_ESP_WAV_DECODER_CONFIG(),
+        DEFAULT_ESP_AAC_DECODER_CONFIG(),
+        DEFAULT_ESP_M4A_DECODER_CONFIG(),
+        DEFAULT_ESP_TS_DECODER_CONFIG(),
+  };
+  esp_decoder_cfg_t auto_dec_cfg = DEFAULT_ESP_DECODER_CONFIG();
+  auto_dec_cfg.out_rb_size = 500 * 1024;
+  decoder_ = esp_decoder_init(&auto_dec_cfg, auto_decode, 10);
+  
   sdk_audio_elements_.push_back(this->decoder_);
   sdk_element_tags_.push_back("decoder");
   this->element_state_ = PipelineElementState::INITIALIZED;

--- a/esphome/components/adf_pipeline/adf_audio_sources.cpp
+++ b/esphome/components/adf_pipeline/adf_audio_sources.cpp
@@ -66,9 +66,10 @@ void HTTPStreamReaderAndDecoder::reset_() {
   this->element_state_ = PipelineElementState::INITIALIZED;
 }
 
-void HTTPStreamReaderAndDecoder::set_stream_uri(const std::string& new_url) {
+void HTTPStreamReaderAndDecoder::set_stream_uri(const std::string& new_url, bool isAnnouncement) {
   esph_log_v(TAG, "Set URI: %s", new_url.c_str());
   this->current_url_ = new_url;
+  this->announcement_ = isAnnouncement;
 }
 
 void HTTPStreamReaderAndDecoder::prepare_elements(){

--- a/esphome/components/adf_pipeline/adf_audio_sources.cpp
+++ b/esphome/components/adf_pipeline/adf_audio_sources.cpp
@@ -25,7 +25,7 @@ bool HTTPStreamReaderAndDecoder::init_adf_elements_() {
 
   http_stream_cfg_t http_cfg = HTTP_STREAM_CFG_DEFAULT();
   //http_cfg.task_core = 0;
-  http_cfg.out_rb_size = 1024 * 1024;
+  http_cfg.out_rb_size = 500 * 1024;
   http_stream_reader_ = http_stream_init(&http_cfg);
   //http_stream_reader_->buf_size =  1024;
   audio_element_set_uri(this->http_stream_reader_, this->current_url_.c_str());
@@ -157,12 +157,6 @@ void HTTPStreamReaderAndDecoder::sdk_event_handler_(audio_event_iface_msg_t &msg
       this->terminate_prepare_pipeline_();
     }
   }
-}
-
-int64_t HTTPStreamReaderAndDecoder::get_position() {
-  audio_element_info_t music_info{};
-  audio_element_getinfo(decoder_, &music_info);
-  return music_info.byte_pos;
 }
 
 /*

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -18,8 +18,8 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
   const std::string get_name() override { return "HTTPStreamReader"; }
   bool is_ready() override;
   void prepare_elements() override;
-  int64_t get_position();
   bool is_announcement() { return announcement_; }
+  audio_element_handle_t get_decoder() { return decoder_; }
 
  protected:
   bool init_adf_elements_() override;

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -14,11 +14,12 @@ class ADFPipelineSourceElement : public ADFPipelineElement {
 
 class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
  public:
-  void set_stream_uri(const std::string&  new_url);
+  void set_stream_uri(const std::string&  new_url, bool is_announcement = false);
   const std::string get_name() override { return "HTTPStreamReader"; }
   bool is_ready() override;
   void prepare_elements() override;
   int64_t get_position();
+  bool is_announcement() { return announcement_; }
 
  protected:
   bool init_adf_elements_() override;
@@ -36,6 +37,7 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
   std::string current_url_{"https://dl.espressif.com/dl/audio/ff-16b-2c-44100hz.mp3"};
   audio_element_handle_t http_stream_reader_{};
   audio_element_handle_t decoder_{};
+  bool announcement_{false};
 };
 
 

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -7,6 +7,8 @@
 namespace esphome {
 namespace esp_adf {
 
+enum class ADFEncoding : uint8_t { AAC = 0, AMR, FLAC, MP3, OGG, OPUS, WAV};
+
 class ADFPipelineSourceElement : public ADFPipelineElement {
  public:
   AudioPipelineElementType get_element_type() const { return AudioPipelineElementType::AUDIO_PIPELINE_SOURCE; }
@@ -18,6 +20,7 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
   const std::string get_name() override { return "HTTPStreamReader"; }
   bool is_ready() override;
   void prepare_elements() override;
+  ADFEncoding decoder_type{ADFEncoding::MP3};
 
  protected:
   bool init_adf_elements_() override;

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -20,7 +20,6 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
   const std::string get_name() override { return "HTTPStreamReader"; }
   bool is_ready() override;
   void prepare_elements() override;
-  ADFEncoding decoder_type{ADFEncoding::MP3};
 
  protected:
   bool init_adf_elements_() override;

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -7,8 +7,6 @@
 namespace esphome {
 namespace esp_adf {
 
-enum class ADFEncoding : uint8_t { AAC = 0, AMR, FLAC, MP3, OGG, OPUS, WAV};
-
 class ADFPipelineSourceElement : public ADFPipelineElement {
  public:
   AudioPipelineElementType get_element_type() const { return AudioPipelineElementType::AUDIO_PIPELINE_SOURCE; }

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -18,6 +18,7 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
   const std::string get_name() override { return "HTTPStreamReader"; }
   bool is_ready() override;
   void prepare_elements() override;
+  int64_t get_position();
 
  protected:
   bool init_adf_elements_() override;

--- a/esphome/components/adf_pipeline/adf_pipeline.cpp
+++ b/esphome/components/adf_pipeline/adf_pipeline.cpp
@@ -13,30 +13,30 @@ static const char *const TAG = "esp_adf_pipeline";
 
 static const uint32_t PIPELINE_PREPARATION_TIMEOUT_MS = 10000;
 
-static const LogString *pipeline_state_to_string(PipelineState state) {
+const char *pipeline_state_to_string(PipelineState state) {
   switch (state) {
     case PipelineState::UNINITIALIZED:
-      return LOG_STR("UNINITIALIZED");
+      return "UNINITIALIZED";
     case PipelineState::PREPARING:
-      return LOG_STR("PREPARING");
+      return "PREPARING";
     case PipelineState::STARTING:
-      return LOG_STR("STARTING");
+      return "STARTING";
     case PipelineState::RUNNING:
-      return LOG_STR("RUNNING");
+      return "RUNNING";
     case PipelineState::STOPPING:
-      return LOG_STR("STOPPING");
+      return "STOPPING";
     case PipelineState::STOPPED:
-      return LOG_STR("STOPPED");
+      return "STOPPED";
     case PipelineState::PAUSING:
-      return LOG_STR("PAUSING");
+      return "PAUSING";
     case PipelineState::PAUSED:
-      return LOG_STR("PAUSED");
+      return "PAUSED";
     case PipelineState::RESUMING:
-      return LOG_STR("RESUMING");
+      return "RESUMING";
     case PipelineState::DESTROYING:
-      return LOG_STR("DESTROYING");
+      return "DESTROYING";
     default:
-      return LOG_STR("UNKNOWN");
+      return "UNKNOWN";
   }
 }
 
@@ -47,7 +47,7 @@ void ADFPipeline::dump_element_configs(){
 }
 
 void ADFPipeline::start() {
-  esph_log_d(TAG, "Starting request, current state %s", LOG_STR_ARG(pipeline_state_to_string(this->state_)));
+  esph_log_d(TAG, "Starting request, current state %s", pipeline_state_to_string(this->state_));
   switch( this->state_ ){
     case PipelineState::UNINITIALIZED:
       if( init_() ){
@@ -82,7 +82,7 @@ void ADFPipeline::stop() {
       set_state_(PipelineState::STOPPING);
       break;
     default:
-      esph_log_d(TAG, "Called 'stop' while in %s state.",LOG_STR_ARG(pipeline_state_to_string(this->state_)) );
+      esph_log_d(TAG, "Called 'stop' while in %s state.",pipeline_state_to_string(this->state_) );
       break;
   }
 }
@@ -92,7 +92,7 @@ void ADFPipeline::pause() {
     set_state_(PipelineState::PAUSING);
     pause_();
   } else {
-    esph_log_d(TAG, "Pipeline was not RUNNING while calling pause! Current state: %s",LOG_STR_ARG(pipeline_state_to_string(this->state_)) );
+    esph_log_d(TAG, "Pipeline was not RUNNING while calling pause! Current state: %s",pipeline_state_to_string(this->state_) );
   }
 }
 
@@ -102,7 +102,7 @@ void ADFPipeline::resume() {
     resume_();
   }
   else {
-    esph_log_d(TAG, "Pipeline was not PAUSED while calling resume! Current state: %s",LOG_STR_ARG(pipeline_state_to_string(this->state_)) );
+    esph_log_d(TAG, "Pipeline was not PAUSED while calling resume! Current state: %s",pipeline_state_to_string(this->state_) );
   }
 }
 
@@ -301,8 +301,8 @@ bool ADFPipeline::request_settings(AudioPipelineSettingsRequest &request) {
 }
 
 void ADFPipeline::set_state_(PipelineState state) {
-  esph_log_d(TAG, "State changed from %s to %s", LOG_STR_ARG(pipeline_state_to_string(this->state_)),
-             LOG_STR_ARG(pipeline_state_to_string(state)));
+  esph_log_d(TAG, "State changed from %s to %s", pipeline_state_to_string(this->state_),
+             pipeline_state_to_string(state));
   state_ = state;
   for (auto element : pipeline_elements_) {
     element->on_pipeline_status_change();

--- a/esphome/components/adf_pipeline/adf_pipeline.cpp
+++ b/esphome/components/adf_pipeline/adf_pipeline.cpp
@@ -195,14 +195,15 @@ void ADFPipeline::check_if_components_are_ready_(){
 }
 
 void ADFPipeline::check_for_pipeline_events_(){
+  
   audio_event_iface_msg_t msg;
   esp_err_t ret = audio_event_iface_listen(this->adf_pipeline_event_, &msg, 0);
   if (ret == ESP_OK) {
     forward_event_to_pipeline_elements_(msg);
 
-      if (parent_ != nullptr) {
-        parent_->pipeline_event_handler(msg);
-      }
+    if (parent_ != nullptr) {
+      parent_->pipeline_event_handler(msg);
+    }
 
     assert( this->state_ != PipelineState::PREPARING );
 

--- a/esphome/components/adf_pipeline/adf_pipeline.cpp
+++ b/esphome/components/adf_pipeline/adf_pipeline.cpp
@@ -378,8 +378,12 @@ bool ADFPipeline::build_adf_pipeline_() {
 }
 
 bool ADFPipeline::reset_() {
+  return reset(false);
+}
+
+bool ADFPipeline::reset(bool force) {
   bool ret = false;
-  if ( this->destroy_on_stop_ ){
+  if ( this->destroy_on_stop_ || force ){
     ret = deinit_();
   }
   else {

--- a/esphome/components/adf_pipeline/adf_pipeline.cpp
+++ b/esphome/components/adf_pipeline/adf_pipeline.cpp
@@ -225,7 +225,9 @@ void ADFPipeline::check_for_pipeline_events_(){
             check_all_started_();
             break;
           case AEL_STATUS_STATE_PAUSED:
-            set_state_(PipelineState::PAUSED);
+            if (strcmp(audio_element_get_tag(el), "i2s_out") == 0) {
+              set_state_(PipelineState::PAUSED);
+            }
             break;
           default:
             break;

--- a/esphome/components/adf_pipeline/adf_pipeline.cpp
+++ b/esphome/components/adf_pipeline/adf_pipeline.cpp
@@ -215,7 +215,7 @@ void ADFPipeline::check_for_pipeline_events_(){
         switch (status) {
           case AEL_STATUS_STATE_STOPPED:
           case AEL_STATUS_STATE_FINISHED:
-            if( this->state_ == PipelineState::RUNNING){
+            if( strcmp(audio_element_get_tag(el), "i2s_out") == 0 && this->state_ == PipelineState::RUNNING){
               this->set_state_(PipelineState::STOPPING);
               check_all_stopped_();
             }

--- a/esphome/components/adf_pipeline/adf_pipeline.h
+++ b/esphome/components/adf_pipeline/adf_pipeline.h
@@ -39,6 +39,7 @@ State Explanations:
 */
 enum PipelineState : uint8_t { UNINITIALIZED = 0, PREPARING, STARTING, RUNNING, STOPPING, STOPPED, PAUSING, PAUSED, RESUMING, DESTROYING };
 
+const char *pipeline_state_to_string(PipelineState state);
 
 class ADFPipelineController;
 

--- a/esphome/components/adf_pipeline/adf_pipeline.h
+++ b/esphome/components/adf_pipeline/adf_pipeline.h
@@ -70,6 +70,7 @@ class ADFPipeline {
   // Send a settings request to all pipeline elements
   bool request_settings(AudioPipelineSettingsRequest &request);
   void on_settings_request_failed(AudioPipelineSettingsRequest request) {}
+  audio_element_handle_t get_last_audio_element() { return adf_last_element_in_pipeline_; }
 
  protected:
   bool init_();

--- a/esphome/components/adf_pipeline/adf_pipeline.h
+++ b/esphome/components/adf_pipeline/adf_pipeline.h
@@ -60,6 +60,7 @@ class ADFPipeline {
   void loop() { this->watch_(); }
 
   void set_destroy_on_stop(bool value){ this->destroy_on_stop_ = value; }
+  bool is_destroy_on_stop(){ return this->destroy_on_stop_; }
   void append_element(ADFPipelineElement *element);
   int get_number_of_elements() { return pipeline_elements_.size(); }
   std::vector<std::string> get_element_names();

--- a/esphome/components/adf_pipeline/adf_pipeline.h
+++ b/esphome/components/adf_pipeline/adf_pipeline.h
@@ -55,6 +55,7 @@ class ADFPipeline {
   void pause();
   void resume();
   void destroy();
+  bool reset(bool force);
 
   PipelineState getState() { return state_; }
   void loop() { this->watch_(); }

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
@@ -48,36 +48,7 @@ void ADFMediaPlayer::set_stream_uri(const std::string& new_uri) {
 
     uri = playlist_[id].uri;
   }
-  set_decoder_type_(uri);
   http_and_decoder_.set_stream_uri(uri);
-}
-
-void ADFMediaPlayer::set_decoder_type_(const std::string& uri) {
-  
-  if (uri.find(".aac") != std::string::npos) {
-    http_and_decoder_.decoder_type = ADFEncoding::AAC;
-  }
-  else if (uri.find(".amr") != std::string::npos) {
-    http_and_decoder_.decoder_type = ADFEncoding::AMR;
-  }
-  else if (uri.find(".flac") != std::string::npos) {
-    http_and_decoder_.decoder_type = ADFEncoding::FLAC;
-  }
-  else if (uri.find(".mp3") != std::string::npos) {
-    http_and_decoder_.decoder_type = ADFEncoding::MP3;
-  }
-  else if (uri.find(".ogg") != std::string::npos) {
-    http_and_decoder_.decoder_type = ADFEncoding::OGG;
-  }
-  else if (uri.find(".opus") != std::string::npos) {
-    http_and_decoder_.decoder_type = ADFEncoding::OPUS;
-  }
-  else if (uri.find(".wav") != std::string::npos) {
-    http_and_decoder_.decoder_type = ADFEncoding::WAV;
-  }
-  else {
-    http_and_decoder_.decoder_type = ADFEncoding::MP3;
-  }
 }
 
 void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
@@ -318,7 +289,6 @@ void ADFMediaPlayer::play_next_track_on_playlist_(int track_id) {
     int id = next_playlist_track_id_();
     if (id > -1) {
       std::string uri = playlist_[id].uri;
-      set_decoder_type_(uri);
       http_and_decoder_.set_stream_uri(uri);
     }
     else {

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
@@ -97,8 +97,9 @@ void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
   if (call.get_command().has_value()) {
     switch (call.get_command().value()) {
       case media_player::MEDIA_PLAYER_COMMAND_PLAY:
+        this->play_intent_ = true;
+        this->play_track_id_ = -1;
         if (state == media_player::MEDIA_PLAYER_STATE_PLAYING) {
-          this->play_intent_ = true;
           pipeline.stop();
         }
         if (state == media_player::MEDIA_PLAYER_STATE_PAUSED) {

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
@@ -63,8 +63,11 @@ void ADFMediaPlayer::set_decoder_type_(const std::string& uri) {
   else if (uri.find(".opus") != std::string::npos) {
     http_and_decoder_.decoder_type = ADFEncoding::OPUS;
   }
-  else {
+  else if (uri.find(".wav") != std::string::npos) {
     http_and_decoder_.decoder_type = ADFEncoding::WAV;
+  }
+  else {
+    http_and_decoder_.decoder_type = ADFEncoding::MP3;
   }
 }
 
@@ -155,13 +158,16 @@ void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         break;
       }
       case media_player::MEDIA_PLAYER_COMMAND_TOGGLE: {
-        if (state == media_player::MEDIA_PLAYER_STATE_PLAYING || state == media_player::MEDIA_PLAYER_STATE_PAUSED) {
-          pipeline.stop();
-        }
-        if (state == media_player::MEDIA_PLAYER_STATE_NONE || state == media_player::MEDIA_PLAYER_STATE_IDLE) {
-          pipeline.start();
-        }
+        toggle_();
         break;
+      case media_player::MEDIA_PLAYER_COMMAND_TURN_ON: {
+        toggle_();
+        break;
+      }
+      case media_player::MEDIA_PLAYER_COMMAND_TURN_OFF: {
+        toggle_();
+        break;
+      }
       default:
         break;
       }
@@ -252,6 +258,7 @@ void ADFMediaPlayer::on_pipeline_state_change(PipelineState state) {
     default:
       break;
   }
+  this->prior_state = this->state;
 }
 
 void ADFMediaPlayer::play_next_track_on_playlist_(int track_id) {
@@ -425,6 +432,16 @@ int ADFMediaPlayer::parse_m3u_into_playlist_(const char *url)
     esp_http_client_close(client);
     esp_http_client_cleanup(client);
     return rc;
+}
+
+void ADFMediaPlayer::toggle_() {
+  if (button_state) {
+    button_state = false;
+  }
+  else {
+    button_state = true;
+  }
+  publish_button_state();
 }
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
@@ -1,6 +1,8 @@
 #include "adf_media_player.h"
 #include "esphome/core/log.h"
 
+#include <esp_http_client.h>
+
 #ifdef USE_ESP_IDF
 
 namespace esphome {
@@ -19,8 +21,48 @@ void ADFMediaPlayer::dump_config() {
 }
 
 void ADFMediaPlayer::set_stream_uri(const std::string& new_uri) {
-  this->current_uri_ = new_uri;
-  http_and_decoder_.set_stream_uri(new_uri);
+  std::string uri = new_uri;
+  playlist_found_ = false;
+  clean_playlist_track_();
+  if (new_uri.find("m3u") != std::string::npos) {
+    esph_log_d(TAG, "Playlist Found" );
+    playlist_found_ = true;
+
+    //tbd - get file contents and parse
+    int pl = parse_m3u_into_playlist_(uri.c_str());
+    if (pl < 0) {
+      return;
+    }
+    esph_log_d(TAG, "Number of playlist tracks = %d", playlist_.size());
+    int id = next_playlist_track_id_();
+
+    uri = playlist_[id].uri;
+  }
+  
+  ADFEncoding decoder_type = http_and_decoder_.decoder_type;
+
+  if (uri.find(".aac") != std::string::npos) {
+    http_and_decoder_.decoder_type = ADFEncoding::AAC;
+  }
+  else if (uri.find(".amr") != std::string::npos) {
+    http_and_decoder_.decoder_type = ADFEncoding::AMR;
+  }
+  else if (uri.find(".flac") != std::string::npos) {
+    http_and_decoder_.decoder_type = ADFEncoding::FLAC;
+  }
+  else if (uri.find(".mp3") != std::string::npos) {
+    http_and_decoder_.decoder_type = ADFEncoding::MP3;
+  }
+  else if (uri.find(".ogg") != std::string::npos) {
+    http_and_decoder_.decoder_type = ADFEncoding::OGG;
+  }
+  else if (uri.find(".opus") != std::string::npos) {
+    http_and_decoder_.decoder_type = ADFEncoding::OPUS;
+  }
+  else {
+    http_and_decoder_.decoder_type = ADFEncoding::WAV;
+  }
+  http_and_decoder_.set_stream_uri(uri);
 }
 
 void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
@@ -61,6 +103,7 @@ void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         }
         break;
       case media_player::MEDIA_PLAYER_COMMAND_STOP:
+        clean_playlist_track_();
         pipeline.stop();
         break;
       case media_player::MEDIA_PLAYER_COMMAND_MUTE:
@@ -135,7 +178,13 @@ void ADFMediaPlayer::on_pipeline_state_change(PipelineState state) {
   esph_log_i(TAG, "got new pipeline state: %d", (int) state);
   switch (state) {
     case PipelineState::UNINITIALIZED:
+      if (playlist_found_ && pipeline.is_destroy_on_stop()) {
+        play_next_song_on_playlist_();
+      }
     case PipelineState::STOPPED:
+      if (playlist_found_ && !pipeline.is_destroy_on_stop()) {
+        play_next_song_on_playlist_();
+      }
       this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
       publish_state();
       if( this->play_intent_ )
@@ -158,6 +207,151 @@ void ADFMediaPlayer::on_pipeline_state_change(PipelineState state) {
     default:
       break;
   }
+}
+
+void ADFMediaPlayer::play_next_song_on_playlist_() {
+  if (playlist_found_) {
+    set_playlist_track_as_played_();
+    int id = next_playlist_track_id_();
+    if (id > -1) {
+      std::string uri = playlist_[id].uri;
+      http_and_decoder_.decoder_type = ADFEncoding::MP3;
+      if (uri.find(".flac") != std::string::npos) {
+        http_and_decoder_.decoder_type = ADFEncoding::FLAC;
+      }
+      http_and_decoder_.set_stream_uri(uri);
+      this->play_intent_ = true;
+    }
+    else {
+      clean_playlist_track_();
+    }
+  }
+}
+
+void ADFMediaPlayer::clean_playlist_track_()
+{
+  if ( this->playlist_.size() > 0 ) {
+    unsigned int vid = this->playlist_.size();
+    /*
+    for(unsigned int i = 0; i < vid; i++)
+    {
+      delete this->&playlist_[i];
+    }
+    */
+    this->playlist_.clear();
+  }
+}
+
+int ADFMediaPlayer::next_playlist_track_id_()
+{
+  unsigned int vid = this->playlist_.size();
+  if ( vid > 0 ) {
+    for(unsigned int i = 0; i < vid; i++)
+    {
+      bool ip = this->playlist_[i].is_played;
+      if (!ip) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
+void ADFMediaPlayer::set_playlist_track_as_played_()
+{
+  if ( this->playlist_.size() > 0 ) {
+    unsigned int vid = this->playlist_.size();
+    for(unsigned int i = 0; i < vid; i++)
+    {
+      bool ip = this->playlist_[i].is_played;
+      if (!ip) {
+        this->playlist_[i].is_played = true;
+        break;
+      }
+    }
+  }
+}
+
+int ADFMediaPlayer::parse_m3u_into_playlist_(const char *url)
+{
+    esp_http_client_config_t config = {
+        .url = url
+    };
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+
+    char *response;
+    esp_err_t err = esp_http_client_open(client,0);
+    int rc = 0;
+    if (err == ESP_OK) {
+      //int cl = esp_http_client_get_content_length(client);
+      int cl =  esp_http_client_fetch_headers(client);
+      //esph_log_v(TAG, "HTTP Status = %d, content_length = %d", esp_http_client_get_status_code(client), cl);
+      response = (char *)malloc(cl + 1);
+      if (response == NULL) {
+        esph_log_e(TAG, "Cannot malloc http receive buffer");
+        rc = -1;
+      }
+      else {
+        int rl = esp_http_client_read(client, response, cl); 
+        if (rl < 0) {
+          esph_log_e(TAG, "HTTP request failed: %s, ", esp_err_to_name(err));
+          free(response);
+          rc = -1;
+        }
+        else {
+          response[cl] = '\0';
+          //esph_log_v(TAG, "Response: %s", response);
+          size_t start = 0;
+          size_t end;
+          char *ptr;
+          char *buffer = response;
+          bool keeplooping = true;
+          while (keeplooping) {
+            ptr = strchr(buffer , '\n' );
+            if (ptr != NULL)
+            {
+              end = ptr - response;
+            }
+            else {
+              end = cl;
+              keeplooping = false;
+            }
+            size_t lngth = (end - start);
+            //Finding a carriage return, assume its a Windows file and this line ends with "\r\n"
+            if (strchr(buffer,'\r') != NULL) {
+              lngth--;
+            }
+            if (lngth > 0) {
+              char *cLine;
+              cLine = (char *)malloc(lngth + 1);
+              if (cLine == NULL) {
+                esph_log_e(TAG, "Cannot malloc cLine");
+                free(response);
+                rc = -1;
+                break;
+              }
+              sprintf (cLine,"%.*s", lngth, buffer);
+              cLine[lngth] = '\0';
+              if (strchr(cLine,'#') == NULL) {
+                ADFPlaylistTrack track;
+                track.uri = cLine;
+                playlist_.push_back(track);
+              }
+              free(cLine);
+            }
+            start = end + 1;
+            buffer = ptr + 1;
+          }
+          free(response);
+        }
+      }
+    } else {
+        esph_log_e(TAG, "HTTP request failed: %s", esp_err_to_name(err));
+        rc = -1;
+    }
+    esp_http_client_close(client);
+    esp_http_client_cleanup(client);
+    return rc;
 }
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -72,18 +72,20 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void resume_();
   void player_resume_();
   bool is_announcement_();
-  void uninitialize_();
+  void player_uninitialize_();
+  void listen_();
+  void unlisten_();
 
   void mrm_process_recv_actions_();
   void mrm_process_send_actions_();
   void mrm_sync_position_(int64_t timestamp, int64_t position);
   void mrm_send_position_();
+  void mrm_command_(const std::string command);
   void mrm_set_stream_uri_(const std::string url);
   void mrm_start_();
   void mrm_stop_();
   void mrm_resume_();
   void mrm_uninitialize_();
-  bool mrm_listen_requested_{false};
   void mrm_listen_();
   void mrm_unlisten_();
   void mrm_turn_on_();
@@ -141,8 +143,6 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void set_playlist_track_(ADFPlaylistTrack track);
   UdpMRM udpMRM_;
   int64_t position_timestamp_{0};
-
-  esp_err_t i2s_stream_sync_delay_(audio_element_handle_t i2s_stream, int32_t delay_size);
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -15,6 +15,9 @@ class ADFPlaylistTrack {
     unsigned int order{0};
     std::string uri{""};
     bool is_played{false};
+    std::string artist{""};
+    std::string album{""};
+    std::string title{""};
     
     // Overloading < operator 
     bool operator<(const ADFPlaylistTrack& obj) const
@@ -39,6 +42,9 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   bool is_muted() const override { return this->muted_; }
   std::string repeat() const { return this->repeat_; }
   bool is_shuffle() const override { return this->shuffle_; }
+  std::string artist() const { return this->artist_; }
+  std::string album() const { return this->album_; }
+  std::string title() const { return this->title_; }
   media_player::MediaPlayerTraits get_traits() override;
 
   //
@@ -57,11 +63,17 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void unmute_();
   void set_repeat_(const std::string& repeat);
   void set_shuffle_(bool shuffle);
+  void set_artist_(const std::string& artist) {artist_ = artist;}
+  void set_album_(const std::string& album) {album_ = album;}
+  void set_title_(const std::string& title) {title_ = title;}
   void set_volume_(float volume, bool publish = true);
 
   bool muted_{false};
   std::string repeat_{"off"};
   bool shuffle_{false};
+  std::string artist_{""};
+  std::string album_{""};
+  std::string title_{""};
   bool play_intent_{false};
   bool turning_off_{false};
   std::string current_uri_{};
@@ -80,6 +92,7 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void set_playlist_track_as_played_(int track_id);
   void playlist_add_(const std::string& new_uri);
   int parse_m3u_into_playlist_(const char *url);
+  void set_playlist_track_(ADFPlaylistTrack track);
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -63,6 +63,7 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   int previous_playlist_track_id_();
   void set_playlist_track_as_played_(int track_id);
   int parse_m3u_into_playlist_(const char *url);
+  void toggle_();
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -12,8 +12,15 @@ namespace esp_adf {
 
 class ADFPlaylistTrack {
   public:
+    unsigned int order{0};
     std::string uri{""};
     bool is_played{false};
+    
+    // Overloading < operator 
+    bool operator<(const ADFPlaylistTrack& obj) const
+    { 
+        return order < obj.order; 
+    } 
 };
 
 class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineController {
@@ -30,6 +37,8 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   // MediaPlayer implementations
   bool is_muted() const override { return this->muted_; }
+  std::string repeat() const { return this->repeat_; }
+  bool is_shuffle() const override { return this->shuffle_; }
   media_player::MediaPlayerTraits get_traits() override;
 
   //
@@ -46,12 +55,17 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   void mute_();
   void unmute_();
+  void set_repeat_(const std::string& repeat);
+  void set_shuffle_(bool shuffle);
   void set_volume_(float volume, bool publish = true);
 
   bool muted_{false};
+  std::string repeat_{"off"};
+  bool shuffle_{false};
   bool play_intent_{false};
   bool turning_off_{false};
-  //optional<std::string> current_uri_{};
+  std::string current_uri_{};
+  bool force_publish_{false};
 
   HTTPStreamReaderAndDecoder http_and_decoder_;
 
@@ -64,6 +78,7 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   int next_playlist_track_id_();
   int previous_playlist_track_id_();
   void set_playlist_track_as_played_(int track_id);
+  void playlist_add_(const std::string& new_uri);
   int parse_m3u_into_playlist_(const char *url);
 };
 

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -66,12 +66,23 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void on_pipeline_state_change(PipelineState state);
     
   void start_();
+  void player_start_();
   void stop_();
+  void player_stop_();
+  void resume_();
+  void player_resume_();
+  bool is_announcement_();
+  void uninitialize_();
 
-  void mrm_process_recv_actions_() ;
+  void mrm_process_recv_actions_();
+  void mrm_process_send_actions_();
+  void mrm_sync_position_(int64_t timestamp, int64_t position);
+  void mrm_send_position_();
   void mrm_set_stream_uri_(const std::string url);
   void mrm_start_();
   void mrm_stop_();
+  void mrm_resume_();
+  void mrm_uninitialize_();
   bool mrm_listen_requested_{false};
   void mrm_listen_();
   void mrm_unlisten_();
@@ -128,9 +139,10 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void playlist_add_(const std::string& new_uri, bool toBack);
   int parse_m3u_into_playlist_(const char *url, bool toBack);
   void set_playlist_track_(ADFPlaylistTrack track);
-
-  bool mrm_leader_started_{false};
   UdpMRM udpMRM_;
+  int64_t position_timestamp_{0};
+
+  esp_err_t i2s_stream_sync_delay_(audio_element_handle_t i2s_stream, int32_t delay_size);
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -10,6 +10,12 @@
 namespace esphome {
 namespace esp_adf {
 
+class ADFPlaylistTrack {
+  public:
+    std::string uri{""};
+    bool is_played{false};
+};
+
 class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineController {
  public:
   // Pipeline implementations
@@ -42,9 +48,18 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   bool muted_{false};
   bool play_intent_{false};
-  optional<std::string> current_uri_{};
+  //optional<std::string> current_uri_{};
 
   HTTPStreamReaderAndDecoder http_and_decoder_;
+
+  std::vector<ADFPlaylistTrack > playlist_;
+  bool playlist_found_{false};
+  
+  void play_next_song_on_playlist_();
+  void clean_playlist_track_();
+  int next_playlist_track_id_();
+  void set_playlist_track_as_played_();
+  int parse_m3u_into_playlist_(const char *url);
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -54,11 +54,14 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   std::vector<ADFPlaylistTrack > playlist_;
   bool playlist_found_{false};
+  int play_track_id_{-1};
   
-  void play_next_song_on_playlist_();
+  void play_next_track_on_playlist_(int track_id);
+  void set_decoder_type_(const std::string& uri);
   void clean_playlist_track_();
   int next_playlist_track_id_();
-  void set_playlist_track_as_played_();
+  int previous_playlist_track_id_();
+  void set_playlist_track_as_played_(int track_id);
   int parse_m3u_into_playlist_(const char *url);
 };
 

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -6,6 +6,7 @@
 
 #include "../adf_pipeline_controller.h"
 #include "../adf_audio_sources.h"
+#include "udp_mrm.h"
 
 namespace esphome {
 namespace esp_adf {
@@ -54,10 +55,8 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   int duration() const { return this->duration_; }
   int position() const { return this->position_; }
   media_player::MediaPlayerTraits get_traits() override;
-
-  //
-  void start();
-  void stop();
+  
+  void loop();
 
  protected:
   // MediaPlayer implementation
@@ -65,7 +64,14 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   // Pipeline implementations
   void on_pipeline_state_change(PipelineState state);
-  
+    
+  void start_();
+  void stop_();
+
+  void mrm_process_recv_actions_() ;
+  void mrm_set_stream_uri_(const std::string url);
+  void mrm_start_();
+  void mrm_stop_();
   bool mrm_listen_requested_{false};
   void mrm_listen_();
   void mrm_unlisten_();
@@ -74,8 +80,6 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void mrm_volume_();
   void mrm_mute_();
   void mrm_unmute_();
-  void mrm_start_();
-  void mrm_stop_();
 
   void mute_();
   void unmute_();
@@ -126,6 +130,7 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void set_playlist_track_(ADFPlaylistTrack track);
 
   bool mrm_leader_started_{false};
+  UdpMRM udpMRM_;
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -25,6 +25,8 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }
   void setup() override;
   void dump_config() override;
+  void publish_state();
+  media_player::MediaPlayerState prior_state{media_player::MEDIA_PLAYER_STATE_NONE};
 
   // MediaPlayer implementations
   bool is_muted() const override { return this->muted_; }
@@ -48,6 +50,7 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   bool muted_{false};
   bool play_intent_{false};
+  bool turning_off_{false};
   //optional<std::string> current_uri_{};
 
   HTTPStreamReaderAndDecoder http_and_decoder_;
@@ -63,7 +66,6 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   int previous_playlist_track_id_();
   void set_playlist_track_as_played_(int track_id);
   int parse_m3u_into_playlist_(const char *url);
-  void toggle_();
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -10,14 +10,20 @@
 namespace esphome {
 namespace esp_adf {
 
-class ADFPlaylistTrack {
+class ADFUriTrack {
   public:
-    unsigned int order{0};
     std::string uri{""};
     bool is_played{false};
+};
+
+class ADFPlaylistTrack : public ADFUriTrack {
+  public:
+    unsigned int order{0};
     std::string artist{""};
     std::string album{""};
     std::string title{""};
+    int duration{0};
+    int64_t filesize{0};
     
     // Overloading < operator 
     bool operator<(const ADFPlaylistTrack& obj) const
@@ -45,6 +51,8 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   std::string artist() const { return this->artist_; }
   std::string album() const { return this->album_; }
   std::string title() const { return this->title_; }
+  int duration() const { return this->duration_; }
+  int position() const { return this->position_; }
   media_player::MediaPlayerTraits get_traits() override;
 
   //
@@ -57,7 +65,7 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   // Pipeline implementations
   void on_pipeline_state_change(PipelineState state);
-
+  
   bool mrm_listen_requested_{false};
   void mrm_listen_();
   void mrm_unlisten_();
@@ -77,6 +85,10 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void set_artist_(const std::string& artist) {artist_ = artist;}
   void set_album_(const std::string& album) {album_ = album;}
   void set_title_(const std::string& title) {title_ = title;}
+  void set_duration_(int duration) {duration_ = duration;}
+  void set_filesize_(int64_t filesize) {filesize_ = filesize;}
+  void set_position_(int position) {position_ = position;}
+  void set_position_();
   void set_volume_(float volume, bool publish = true);
 
   bool muted_{false};
@@ -86,6 +98,9 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   std::string artist_{""};
   std::string album_{""};
   std::string title_{""};
+  int duration_{0}; // in seconds
+  int64_t filesize_{0};
+  int position_{0}; // in seconds
   std::string group_members_{""};
   bool play_intent_{false};
   bool turning_off_{false};
@@ -93,18 +108,23 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   HTTPStreamReaderAndDecoder http_and_decoder_;
 
+  std::vector<ADFUriTrack > announcements_;
+  void clean_announcements_();
+  bool play_next_track_on_announcements_();
+
   std::vector<ADFPlaylistTrack > playlist_;
   int play_track_id_{-1};
   
   void update_playlist_order(unsigned int start_order);
   void play_next_track_on_playlist_(int track_id);
-  void clean_playlist_track_();
+  void clean_playlist_();
   int next_playlist_track_id_();
   int previous_playlist_track_id_();
   void set_playlist_track_as_played_(int track_id);
   void playlist_add_(const std::string& new_uri, bool toBack);
   int parse_m3u_into_playlist_(const char *url, bool toBack);
   void set_playlist_track_(ADFPlaylistTrack track);
+
   bool mrm_leader_started_{false};
 };
 

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -60,7 +60,6 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   int play_track_id_{-1};
   
   void play_next_track_on_playlist_(int track_id);
-  void set_decoder_type_(const std::string& uri);
   void clean_playlist_track_();
   int next_playlist_track_id_();
   int previous_playlist_track_id_();

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -40,7 +40,7 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
 
   // MediaPlayer implementations
   bool is_muted() const override { return this->muted_; }
-  std::string repeat() const { return this->repeat_; }
+  std::string repeat() const { return media_player_repeat_mode_to_string(this->repeat_); }
   bool is_shuffle() const override { return this->shuffle_; }
   std::string artist() const { return this->artist_; }
   std::string album() const { return this->album_; }
@@ -48,9 +48,8 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   media_player::MediaPlayerTraits get_traits() override;
 
   //
-  void set_stream_uri(const std::string& new_uri);
-  void start() {pipeline.start();}
-  void stop()  {pipeline.stop();}
+  void start();
+  void stop();
 
  protected:
   // MediaPlayer implementation
@@ -59,9 +58,21 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   // Pipeline implementations
   void on_pipeline_state_change(PipelineState state);
 
+  bool mrm_listen_requested_{false};
+  void mrm_listen_();
+  void mrm_unlisten_();
+  void mrm_turn_on_();
+  void mrm_turn_off_();
+  void mrm_volume_();
+  void mrm_mute_();
+  void mrm_unmute_();
+  void mrm_start_();
+  void mrm_stop_();
+
   void mute_();
   void unmute_();
-  void set_repeat_(const std::string& repeat);
+  void set_mrm_(media_player::MediaPlayerMRM mrm);
+  void set_repeat_(media_player::MediaPlayerRepeatMode repeat);
   void set_shuffle_(bool shuffle);
   void set_artist_(const std::string& artist) {artist_ = artist;}
   void set_album_(const std::string& album) {album_ = album;}
@@ -69,30 +80,32 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void set_volume_(float volume, bool publish = true);
 
   bool muted_{false};
-  std::string repeat_{"off"};
+  media_player::MediaPlayerMRM mrm_{media_player::MEDIA_PLAYER_MRM_OFF};
+  media_player::MediaPlayerRepeatMode repeat_{media_player::MEDIA_PLAYER_REPEAT_OFF};
   bool shuffle_{false};
   std::string artist_{""};
   std::string album_{""};
   std::string title_{""};
+  std::string group_members_{""};
   bool play_intent_{false};
   bool turning_off_{false};
-  std::string current_uri_{};
   bool force_publish_{false};
 
   HTTPStreamReaderAndDecoder http_and_decoder_;
 
   std::vector<ADFPlaylistTrack > playlist_;
-  bool playlist_found_{false};
   int play_track_id_{-1};
   
+  void update_playlist_order(unsigned int start_order);
   void play_next_track_on_playlist_(int track_id);
   void clean_playlist_track_();
   int next_playlist_track_id_();
   int previous_playlist_track_id_();
   void set_playlist_track_as_played_(int track_id);
-  void playlist_add_(const std::string& new_uri);
-  int parse_m3u_into_playlist_(const char *url);
+  void playlist_add_(const std::string& new_uri, bool toBack);
+  int parse_m3u_into_playlist_(const char *url, bool toBack);
   void set_playlist_track_(ADFPlaylistTrack track);
+  bool mrm_leader_started_{false};
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/udp_mrm.cpp
+++ b/esphome/components/adf_pipeline/media_player/udp_mrm.cpp
@@ -1,0 +1,386 @@
+#include "udp_mrm.h"
+
+#include <string.h>
+#include <sstream>
+#include <sys/param.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/event_groups.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esphome/core/log.h"
+#include "nvs_flash.h"
+#include "esp_netif.h"
+
+#include "lwip/err.h"
+#include "lwip/sockets.h"
+#include "lwip/sys.h"
+#include <lwip/netdb.h>
+#include <cJSON.h>
+
+#ifdef USE_ESP_IDF
+
+namespace esphome {
+namespace esp_adf {
+
+static const char *const TAG = "udp_mcast";
+
+static void mrm_task(void *pvParameters)
+{
+  UdpMRM& self = *((UdpMRM*)pvParameters);
+
+  // outer loop
+  while (true) {
+
+    char recvbuf[self.multicast_buffer_size];
+    char addr_name[32] = { 0 };
+
+    // create socket
+    int sock = self.create_multicast_ipv4_socket();
+    if (sock < 0) {
+      esph_log_e(TAG, "Failed to create IPv4 multicast socket");
+      vTaskDelay(5 / portTICK_PERIOD_MS);
+      // try again
+      continue;
+    }
+
+    // set destination multicast addresses for sending from these sockets
+    struct sockaddr_in sdestv4 = {
+      .sin_family = PF_INET,
+      .sin_port = htons(self.udp_port),
+    };
+    // We know this inet_aton will pass because we did it above already
+    inet_aton(self.multicast_ipv4_addr.c_str(), &sdestv4.sin_addr.s_addr);
+
+    // Loop first look for UDP packets and then send UDP packets if send_actions.
+    // see any.
+    int err = 1;
+
+    // inner loop
+    while (err > 0) {
+
+      // break out if stop requested
+      if (self.stop_multicast) {
+        esph_log_d(TAG, "Stopping multicast");
+        break;
+      }
+
+      struct timeval tv = {
+        .tv_sec = 2,
+        .tv_usec = 0,
+      };
+      fd_set rfds;
+      FD_ZERO(&rfds);
+      FD_SET(sock, &rfds);
+
+      int s = select(sock + 1, &rfds, NULL, NULL, &tv);
+
+      // socket failure
+      if (s < 0) {
+        esph_log_e(TAG, "Select failed: errno %d", errno);
+        err = s;
+        // break out to outer loop
+        break;
+      }
+      // socket has incoming datagram
+      if (s > 0) {
+        if (FD_ISSET(sock, &rfds)) {
+          // Incoming datagram received
+          struct sockaddr_storage raddr; // Large enough for both IPv4 or IPv6
+          socklen_t socklen = sizeof(raddr);
+          int len = recvfrom(sock, recvbuf, sizeof(recvbuf)-1, 0, (struct sockaddr *)&raddr, &socklen);
+          if (len < 0) {
+            esph_log_e(TAG, "multicast recvfrom failed: errno %d", errno);
+            err = -1;
+            break;
+          }
+
+          // Get the sender's address as a string
+          if (raddr.ss_family == PF_INET) {
+            inet_ntoa_r(((struct sockaddr_in *)&raddr)->sin_addr, addr_name, sizeof(addr_name)-1);
+          }
+
+          esph_log_v(TAG, "received %d bytes from %s:", len, addr_name);
+
+          recvbuf[len] = 0; // Null-terminate whatever we received and treat like a string...
+          esph_log_v(TAG, "%s", recvbuf);
+          std::string message = recvbuf;
+          std::string address = addr_name;
+          self.process_multicast_message(message, address);
+        }
+      }
+      
+      // send messages to multicast
+      if (self.send_actions.size() > 0) {
+        std::string message = self.send_actions.front().to_string();
+        esph_log_d(TAG, "Send: %s", message.c_str());
+        int len = message.length();
+        if (len > self.multicast_buffer_size) {
+          ESP_LOGE(TAG, "%d is larger than will be able to be received: %d", len, self.multicast_buffer_size);
+          err = -1;
+          break;
+        }
+
+        struct addrinfo hints = {
+          .ai_flags = AI_PASSIVE,
+          .ai_socktype = SOCK_DGRAM,
+        };
+        struct addrinfo *res;
+        hints.ai_family = AF_INET; // For an IPv4 socket
+
+        int err = getaddrinfo(self.multicast_ipv4_addr.c_str(), NULL, &hints, &res);
+        if (err < 0) {
+          esph_log_e(TAG, "getaddrinfo() failed for IPV4 destination address. error: %d", err);
+          break;
+        }
+        if (res == 0) {
+          esph_log_e(TAG, "getaddrinfo() did not return any addresses");
+          break;
+        }
+        ((struct sockaddr_in *)res->ai_addr)->sin_port = htons(self.udp_port);
+        inet_ntoa_r(((struct sockaddr_in *)res->ai_addr)->sin_addr, addr_name, sizeof(addr_name)-1);
+        esph_log_v(TAG, "Sending to IPV4 multicast address %s:%d...",  addr_name, self.udp_port);
+        esph_log_v(TAG, "message: %s, length: %d",message.c_str(), len);
+        err = sendto(sock, message.c_str(), len, 0, res->ai_addr, res->ai_addrlen);
+        freeaddrinfo(res);
+        if (err < 0) {
+          esph_log_e(TAG, "IPV4 sendto failed. errno: %d", errno);
+          break;
+        }
+        self.send_actions.pop();
+      }
+      vTaskDelay(self.multicast_loop_sleep_ms / portTICK_PERIOD_MS);
+    }
+    esph_log_d(TAG, "Shutdown and close socket");
+    shutdown(sock, 0);
+    close(sock);
+    if (self.stop_multicast) {
+      self.multicast_running = false;
+      self.stop_multicast = false;
+      vTaskDelete(self.xhandle);
+      break;
+    }
+    else {
+      esph_log_d(TAG, "Restarting ...");
+    }
+  }
+}
+
+/* below are class methods */
+
+
+std::string UdpMRMAction::to_string() {
+
+  std::string message = "{\"action\":\"" + this->type + "\"";
+
+  if (this->type == "ping_response") {;
+    std::ostringstream otimestamp;
+    otimestamp << this->timestamp;
+    // send time as a string so that cJSON can parse
+    message += ",\"time\":\"" + otimestamp.str()+"\"";
+    message += ",\"sender\":\"" + data +"\"";
+  }
+  else if (this->type == "url") {
+    message += ",\"url\":\"" + this->data + "\"";
+  }
+  message += "}";
+  return message;
+}
+
+void UdpMRM::listen(media_player::MediaPlayerMRM mrm) {
+  mrm_ = mrm;
+  stop_multicast = false;
+  if (!multicast_running) {
+    esph_log_d(TAG, "Start multicast");
+    esph_log_d(TAG, "Create Task");
+    xTaskCreate(&mrm_task, "mrm_task", 4096, this, 5, &xhandle);
+    multicast_running = true;
+  }
+  else {
+    esph_log_d(TAG, "Task already exists");
+  }
+}
+
+void UdpMRM::unlisten() {
+  esph_log_d(TAG, "Stop multicast");
+  stop_multicast = true;
+}
+
+void UdpMRM::set_stream_uri(const std::string& url) {
+  esph_log_d(TAG, "set follower uri");
+  UdpMRMAction action;
+  action.type = "url";
+  action.data = url;
+  send_actions.push(action);
+}
+
+void UdpMRM::start() {
+  esph_log_d(TAG, "Start follower media players");
+  UdpMRMAction action;
+  action.type = "start";
+  send_actions.push(action);
+}
+
+void UdpMRM::stop() {
+  esph_log_d(TAG, "Stop follower media players");
+  UdpMRMAction action;
+  action.type = "stop";
+  send_actions.push(action);
+}
+
+void UdpMRM::process_multicast_message(std::string &message, std::string &sender) {
+  if (message.length()) {
+    esph_log_d(TAG, "Received: %s from %s", message.c_str(), sender.c_str());
+    
+    cJSON *root = cJSON_Parse(message.c_str());
+    std::string action = cJSON_GetObjectItem(root,"action")->valuestring;
+    if (action == "ping" && get_mrm() == media_player::MEDIA_PLAYER_MRM_LEADER) {
+      UdpMRMAction action;
+      action.type = "ping_response";
+      action.data = sender;
+      action.timestamp = get_timestamp();
+      send_actions.push(action);
+    }
+    if (action == "ping_response" && get_mrm() == media_player::MEDIA_PLAYER_MRM_FOLLOWER) {
+      std::string leader_timestamp_str = cJSON_GetObjectItem(root,"time")->valuestring;
+      int64_t leader_timestamp = 0;
+
+      int64_t half_duration = (get_timestamp() - ping_timestamp_) / 2;
+      offset = ((leader_timestamp - half_duration) - ping_timestamp_);
+    }
+    else if (action == "start" && get_mrm() == media_player::MEDIA_PLAYER_MRM_FOLLOWER) {
+      UdpMRMAction action;
+      action.type = "start";
+      recv_actions.push(action);
+    }
+    else if (action == "stop" && get_mrm() == media_player::MEDIA_PLAYER_MRM_FOLLOWER) {
+      UdpMRMAction action;
+      action.type = "stop";
+      recv_actions.push(action);
+    }
+    else if (action == "url" && get_mrm() == media_player::MEDIA_PLAYER_MRM_FOLLOWER) {
+      std::string url = cJSON_GetObjectItem(root,"url")->valuestring;
+      UdpMRMAction action;
+      action.type = "url";
+      action.data = url;
+      recv_actions.push(action);
+    }
+  }
+}
+
+int64_t UdpMRM::get_timestamp() {
+  struct timeval tv_now;
+  gettimeofday(&tv_now, NULL);
+  return (int64_t)tv_now.tv_sec * 1000000L + (int64_t)tv_now.tv_usec;
+}
+
+/* Add a socket to the IPV4 multicast group */
+int UdpMRM::socket_add_ipv4_multicast_group(int sock, bool assign_source_if)
+{
+  struct ip_mreq imreq = { 0 };
+  struct in_addr iaddr = { 0 };
+  int err = 0;
+  // Configure source interface
+  if (this->listen_all_if) {
+    imreq.imr_interface.s_addr = IPADDR_ANY;
+  } else {
+    /* TBD - need to replace get_example_netif with correct call
+    esp_netif_ip_info_t ip_info = { 0 };
+    err = esp_netif_get_ip_info(get_example_netif(), &ip_info);
+    if (err != ESP_OK) {
+      esph_log_e(TAG, "Failed to get IP address info. Error 0x%x", err);
+      return err;
+    }
+    inet_addr_from_ip4addr(&iaddr, &ip_info.ip);
+    */
+  }
+  // Configure multicast address to listen to
+  err = inet_aton(this->multicast_ipv4_addr.c_str(), &imreq.imr_multiaddr.s_addr);
+  if (err != 1) {
+    esph_log_e(TAG, "Configured IPV4 multicast address '%s' is invalid.", this->multicast_ipv4_addr.c_str());
+    // Errors in the return value have to be negative
+    err = -1;
+    return err;
+  }
+  esph_log_i(TAG, "Configured IPV4 Multicast address %s", inet_ntoa(imreq.imr_multiaddr.s_addr));
+  if (!IP_MULTICAST(ntohl(imreq.imr_multiaddr.s_addr))) {
+    esph_log_w(TAG, "Configured IPV4 multicast address '%s' is not a valid multicast address. This will probably not work.", this->multicast_ipv4_addr.c_str());
+  }
+
+  if (assign_source_if) {
+    // Assign the IPv4 multicast source interface, via its IP
+    // (only necessary if this socket is IPV4 only)
+    err = setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, &iaddr,
+             sizeof(struct in_addr));
+    if (err < 0) {
+      esph_log_e(TAG, "Failed to set IP_MULTICAST_IF. Error %d", errno);
+      return err;
+    }
+  }
+
+  err = setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+             &imreq, sizeof(struct ip_mreq));
+  if (err < 0) {
+    esph_log_e(TAG, "Failed to set IP_ADD_MEMBERSHIP. Error %d", errno);
+    return err;
+  }
+
+  return ESP_OK;
+}
+
+int UdpMRM::create_multicast_ipv4_socket(void)
+{
+  struct sockaddr_in saddr = { 0 };
+  int sock = -1;
+  int err = 0;
+
+  sock = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
+  if (sock < 0) {
+    esph_log_e(TAG, "Failed to create socket. Error %d", errno);
+    return -1;
+  }
+
+  // Bind the socket to any address
+  saddr.sin_family = PF_INET;
+  saddr.sin_port = htons(this->udp_port);
+  saddr.sin_addr.s_addr = htonl(INADDR_ANY);
+  err = bind(sock, (struct sockaddr *)&saddr, sizeof(struct sockaddr_in));
+  if (err < 0) {
+    esph_log_e(TAG, "Failed to bind socket. Error %d", errno);
+    close(sock);
+    return err;
+  }
+
+  // Assign multicast TTL (set separately from normal interface TTL)
+  uint8_t ttl = this->multicast_ttl;
+  err = setsockopt(sock, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(uint8_t));
+  if (err < 0) {
+    esph_log_e(TAG, "Failed to set IP_MULTICAST_TTL. Error %d", errno);
+    close(sock);
+    return err;
+  }
+
+  uint8_t loopback_val = true;
+  err = setsockopt(sock, IPPROTO_IP, IP_MULTICAST_LOOP, &loopback_val, sizeof(uint8_t));
+  if (err < 0) {
+    esph_log_e(TAG, "Failed to set IP_MULTICAST_LOOP. Error %d", errno);
+    close(sock);
+    return err;
+  }
+
+  // this is also a listening socket, so add it to the multicast
+  // group for listening...
+  err = socket_add_ipv4_multicast_group(sock, true);
+  if (err < 0) {
+    close(sock);
+    return err;
+  }
+
+  // All set, socket is configured for sending and receiving
+  return sock;
+}
+
+}  // namespace esp_adf
+}  // namespace esphome
+#endif

--- a/esphome/components/adf_pipeline/media_player/udp_mrm.h
+++ b/esphome/components/adf_pipeline/media_player/udp_mrm.h
@@ -15,6 +15,7 @@ class UdpMRMAction {
   public:
     std::string type{""};
     std::string data{""};
+    std::string data1{""};
     int64_t timestamp{};
     std::string to_string();
     int64_t get_timestamp();
@@ -35,17 +36,13 @@ class UdpMRM {
     size_t multicast_buffer_size{512};
     bool multicast_running{false};
     TaskHandle_t xhandle{};
+    std::queue<int64_t> offsets;
     int64_t offset{};
     std::queue<UdpMRMAction> send_actions;
     std::queue<UdpMRMAction> recv_actions;
 
     void listen(media_player::MediaPlayerMRM mrm);
     void unlisten();
-    void set_stream_uri(const std::string& url);
-    void start();
-    void stop();
-    void resume();
-    void uninitialize();
     void send_ping();
     void send_position(int64_t timestamp, int64_t position);
 
@@ -57,7 +54,9 @@ class UdpMRM {
     int socket_add_ipv4_multicast_group(int sock, bool assign_source_if);
     int create_multicast_ipv4_socket(void);
     void process_multicast_message(std::string &message, std::string &sender);
-    int64_t ping_timestamp{};
+    int64_t ping_startup_timestamp{0};
+    int64_t ping_send_timestamp{0};
+    uint ping_startup_cnt{0};
 
   protected:
     media_player::MediaPlayerMRM mrm_{media_player::MEDIA_PLAYER_MRM_OFF};

--- a/esphome/components/adf_pipeline/media_player/udp_mrm.h
+++ b/esphome/components/adf_pipeline/media_player/udp_mrm.h
@@ -17,17 +17,22 @@ class UdpMRMAction {
     std::string data{""};
     int64_t timestamp{};
     std::string to_string();
+    int64_t get_timestamp();
 };
 
 class UdpMRM {
   public:
+    // should be configurable through yaml
     std::string multicast_ipv4_addr{"239.255.255.252"};
-    int udp_port{1900};
-    uint8_t multicast_ttl{5};
-    bool listen_all_if{true};
+    //port 1900 is in use, avoid
+    int udp_port{1901};
+    uint8_t multicast_ttl{2};
+    bool listen_all_if{false};
+
+    // internal
+    std::string this_addr_{""};
     bool stop_multicast{false};
-    size_t multicast_buffer_size{1024};
-    int multicast_loop_sleep_ms{500};
+    size_t multicast_buffer_size{512};
     bool multicast_running{false};
     TaskHandle_t xhandle{};
     int64_t offset{};
@@ -39,6 +44,11 @@ class UdpMRM {
     void set_stream_uri(const std::string& url);
     void start();
     void stop();
+    void resume();
+    void uninitialize();
+    void send_ping();
+    void send_position(int64_t timestamp, int64_t position);
+
     media_player::MediaPlayerMRM get_mrm() { return mrm_; }
 
     int64_t get_timestamp();
@@ -46,13 +56,11 @@ class UdpMRM {
     //used by mrm_task
     int socket_add_ipv4_multicast_group(int sock, bool assign_source_if);
     int create_multicast_ipv4_socket(void);
-    int create_multicast_ipv6_socket(void);
     void process_multicast_message(std::string &message, std::string &sender);
-    std::string prepare_multicast_message();
+    int64_t ping_timestamp{};
 
   protected:
     media_player::MediaPlayerMRM mrm_{media_player::MEDIA_PLAYER_MRM_OFF};
-    int64_t ping_timestamp_{};
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/udp_mrm.h
+++ b/esphome/components/adf_pipeline/media_player/udp_mrm.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <string>
+#include <queue>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esphome/components/media_player/media_player.h"
+
+#ifdef USE_ESP_IDF
+
+namespace esphome {
+namespace esp_adf {
+
+class UdpMRMAction {
+  public:
+    std::string type{""};
+    std::string data{""};
+    int64_t timestamp{};
+    std::string to_string();
+};
+
+class UdpMRM {
+  public:
+    std::string multicast_ipv4_addr{"239.255.255.252"};
+    int udp_port{1900};
+    uint8_t multicast_ttl{5};
+    bool listen_all_if{true};
+    bool stop_multicast{false};
+    size_t multicast_buffer_size{1024};
+    int multicast_loop_sleep_ms{500};
+    bool multicast_running{false};
+    TaskHandle_t xhandle{};
+    int64_t offset{};
+    std::queue<UdpMRMAction> send_actions;
+    std::queue<UdpMRMAction> recv_actions;
+
+    void listen(media_player::MediaPlayerMRM mrm);
+    void unlisten();
+    void set_stream_uri(const std::string& url);
+    void start();
+    void stop();
+    media_player::MediaPlayerMRM get_mrm() { return mrm_; }
+
+    int64_t get_timestamp();
+
+    //used by mrm_task
+    int socket_add_ipv4_multicast_group(int sock, bool assign_source_if);
+    int create_multicast_ipv4_socket(void);
+    int create_multicast_ipv6_socket(void);
+    void process_multicast_message(std::string &message, std::string &sender);
+    std::string prepare_multicast_message();
+
+  protected:
+    media_player::MediaPlayerMRM mrm_{media_player::MEDIA_PLAYER_MRM_OFF};
+    int64_t ping_timestamp_{};
+};
+
+}  // namespace esp_adf
+}  // namespace esphome
+
+#endif

--- a/esphome/components/i2s_audio/adf_pipeline/adf_i2s_out.cpp
+++ b/esphome/components/i2s_audio/adf_pipeline/adf_i2s_out.cpp
@@ -40,7 +40,7 @@ bool ADFElementI2SOut::init_adf_elements_() {
       .i2s_port = this->parent_->get_port(),
       .use_alc = this->use_adf_alc_,
       .volume = 0,
-      .out_rb_size = I2S_STREAM_RINGBUFFER_SIZE,
+      .out_rb_size = 50 * 1024,
       .task_stack = I2S_STREAM_TASK_STACK,
       .task_core = I2S_STREAM_TASK_CORE,
       .task_prio = I2S_STREAM_TASK_PRIO,

--- a/esphome/components/i2s_audio/adf_pipeline/adf_i2s_out.cpp
+++ b/esphome/components/i2s_audio/adf_pipeline/adf_i2s_out.cpp
@@ -40,7 +40,7 @@ bool ADFElementI2SOut::init_adf_elements_() {
       .i2s_port = this->parent_->get_port(),
       .use_alc = this->use_adf_alc_,
       .volume = 0,
-      .out_rb_size = (4 * 1024),
+      .out_rb_size = I2S_STREAM_RINGBUFFER_SIZE,
       .task_stack = I2S_STREAM_TASK_STACK,
       .task_core = I2S_STREAM_TASK_CORE,
       .task_prio = I2S_STREAM_TASK_PRIO,
@@ -52,7 +52,7 @@ bool ADFElementI2SOut::init_adf_elements_() {
   };
 
   this->adf_i2s_stream_writer_ = i2s_stream_init(&i2s_cfg);
-  this->adf_i2s_stream_writer_->buf_size = 1 * 1024;
+  //this->adf_i2s_stream_writer_->buf_size = 1 * 1024;
 
   this->install_i2s_driver(i2s_config);
 


### PR DESCRIPTION
Added multiple audio formats (via file extensions) including ability to play an m3u file. Only tested with the ESP32-S3-DEVKITC, PCM5102 DAC, media-player (keep_pipeline_alive: false), and m3u files containing full URLs to non secure web-server of flac files.  Added to be able to play m3u files from Media panel in HA.