### PR TITLE
Announcement fixed settings config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ For configuration examples not utilizing the *adf_pipeline*, please refer to the
 - **m5stack-atom-echo-spk.yaml**: Shared I2S port with exclusive access.
 - **m5stack-core-s3-spk.yaml**: includes the use of external DACs and ADCs
 
+#### ADF-MediaPlayer announcement configurations:
+When playing an audio stream the stream is additionally started once silently in the preparation phase in order to detect the audio format and set the pipeline components accordingly. In order to safe some time this detection phase can be skipped for announcements which always have the same audio settings:
+
+```yaml
+media_player:
+  - platform: adf_pipeline
+    id: adf_media_player
+    name: s3-dev_media_player
+    internal: false
+    keep_pipeline_alive: false
+    announcement_audio:
+      sample_rate: 16000
+      bits_per_sample: 16
+      num_channels: 1
+    pipeline:
+      - self
+      - resampler
+      - adf_i2s_out
+
+```
+
 #### ADF-Pipeline configurations:
 
 **Dedicated I2S-Port for Microphone and Speaker/Media Player:**

--- a/esphome/components/adf_pipeline/adf_audio_element.cpp
+++ b/esphome/components/adf_pipeline/adf_audio_element.cpp
@@ -373,14 +373,14 @@ void ADFPipelineElement::replace(ADFPipelineElement* replacement){
       break;
     case PipelineElementState::PAUSED:
     case PipelineElementState::READY:
-      if( this->get_state() == RESUMING || this->get_state() == RUNNING ){
+      if( this->get_state() == PipelineElementState::RESUMING || this->get_state() == PipelineElementState::RUNNING ){
         this->pause_elements(true);
-        this->set_state(PipelineElementState::PAUSING)
-      } else if( this->get_state() == PAUSING ){
+        this->set_state(PipelineElementState::PAUSING);
+      } else if( this->get_state() == PipelineElementState::PAUSING ){
         if (this->pause_elements(false) ){
           this->set_state(PipelineElementState::PAUSED);
         }
-      else if( this->get_state() == STOPPING ){
+      else if( this->get_state() == PipelineElementState::STOPPING ){
         if (this->stop_elements(false) ){
           this->set_state(PipelineElementState::STOPPED);
         }
@@ -390,11 +390,11 @@ void ADFPipelineElement::replace(ADFPipelineElement* replacement){
       }
       else {
         this->stop_elements(true);
-        this->set_state(PipelineElementState::STOPPING)
+        this->set_state(PipelineElementState::STOPPING);
       }
       break;
     default:
-      break
+      break;
   }
 
 }

--- a/esphome/components/adf_pipeline/adf_audio_element.cpp
+++ b/esphome/components/adf_pipeline/adf_audio_element.cpp
@@ -356,50 +356,6 @@ bool ADFPipelineElement::elements_have_stopped(){
   return true;
 }
 
-void ADFPipelineElement::replace(ADFPipelineElement* replacement){
-  switch( replacement->get_state() ){
-    case PipelineElementState::UNINITIALIZED:
-      replacement->init_adf_elements();
-      break;
-    case PipelineElementState::STOPPED:
-    case PipelineElementState::INITIALIZED:
-      replacement->prepare_elements(true);
-      replacement->set_state(PipelineElementState::PREPARING);
-      break;
-    case PipelineElementState::PREPARING:
-      if( replacement->prepare_elements(false) ){
-        replacement->set_state(PipelineElementState::READY);
-      }
-      break;
-    case PipelineElementState::PAUSED:
-    case PipelineElementState::READY:
-      if( this->get_state() == PipelineElementState::RESUMING || this->get_state() == PipelineElementState::RUNNING ){
-        this->pause_elements(true);
-        this->set_state(PipelineElementState::PAUSING);
-      } else if( this->get_state() == PipelineElementState::PAUSING ){
-        if (this->pause_elements(false) ){
-          this->set_state(PipelineElementState::PAUSED);
-        }
-      else if( this->get_state() == PipelineElementState::STOPPING ){
-        if (this->stop_elements(false) ){
-          this->set_state(PipelineElementState::STOPPED);
-        }
-      }
-      } else if( this->get_state() == PipelineElementState::PAUSED || this->get_state() == PipelineElementState::STOPPED ) {
-        //replace
-      }
-      else {
-        this->stop_elements(true);
-        this->set_state(PipelineElementState::STOPPING);
-      }
-      break;
-    default:
-      break;
-  }
-
-}
-
-
 
 }  // namespace esp_adf
 }  // namespace esphome

--- a/esphome/components/adf_pipeline/adf_audio_element.h
+++ b/esphome/components/adf_pipeline/adf_audio_element.h
@@ -24,6 +24,7 @@ class ADFPipelineElement;
 
 enum AudioPipelineElementType : uint8_t { AUDIO_PIPELINE_SOURCE = 0, AUDIO_PIPELINE_SINK, AUDIO_PIPELINE_PROCESS };
 
+
 class AudioPipelineSettingsRequest {
  public:
   AudioPipelineSettingsRequest() = default;
@@ -63,6 +64,7 @@ class ADFPipelineElement {
 
   bool init_adf_elements() { return init_adf_elements_(); }
   void destroy_adf_elements() {clear_adf_elements_();}
+  void replace( ADFPipelineElement* replacement );
 
   bool in_error_state(){ return this->element_state_ == PipelineElementState::ERROR; }
 
@@ -83,6 +85,9 @@ class ADFPipelineElement {
 
   virtual bool is_ready() { return true; }
   virtual bool requires_destruction_on_stop(){ return false; }
+
+  PipelineElementState get_state(){ return this->element_state_; }
+  void set_state(PipelineElementState new_sate){ this->element_state_ = new_state; }
 
  protected:
   friend class ADFPipeline;

--- a/esphome/components/adf_pipeline/adf_audio_element.h
+++ b/esphome/components/adf_pipeline/adf_audio_element.h
@@ -64,7 +64,6 @@ class ADFPipelineElement {
 
   bool init_adf_elements() { return init_adf_elements_(); }
   void destroy_adf_elements() {clear_adf_elements_();}
-  void replace( ADFPipelineElement* replacement );
 
   bool in_error_state(){ return this->element_state_ == PipelineElementState::ERROR; }
 

--- a/esphome/components/adf_pipeline/adf_audio_element.h
+++ b/esphome/components/adf_pipeline/adf_audio_element.h
@@ -87,7 +87,7 @@ class ADFPipelineElement {
   virtual bool requires_destruction_on_stop(){ return false; }
 
   PipelineElementState get_state(){ return this->element_state_; }
-  void set_state(PipelineElementState new_sate){ this->element_state_ = new_state; }
+  void set_state(PipelineElementState new_state){ this->element_state_ = new_state; }
 
  protected:
   friend class ADFPipeline;

--- a/esphome/components/adf_pipeline/adf_audio_sources.cpp
+++ b/esphome/components/adf_pipeline/adf_audio_sources.cpp
@@ -94,17 +94,18 @@ bool HTTPStreamReaderAndDecoder::preparing_step_(){
       break;
 
     case PipelineElementState::PREPARE:
-      esph_log_d(TAG, "Use fixed settings: %s", this->fixed_settings_ ? "yes" : "no");
+      esph_log_d(TAG, "Use fixed settings: %s", this->track_.all_set() ? "yes" : "no");
       esph_log_d(TAG, "Streamer status: %d", audio_element_get_state(this->http_stream_reader_) );
       esph_log_d(TAG, "decoder status: %d", audio_element_get_state(this->decoder_) );
+      esph_log_d(TAG, "stream uri: %s", this->track_.uri.c_str() );
 
-      audio_element_set_uri(this->http_stream_reader_, this->current_url_.c_str());
+      audio_element_set_uri(this->http_stream_reader_, this->track_.uri.c_str());
 
-      if( this->fixed_settings_ ){
+      if( this->track_.all_set() ){
         AudioPipelineSettingsRequest request{this};
-        request.sampling_rate = 16000;
-        request.bit_depth = 16;
-        request.number_of_channels = 1;
+        request.sampling_rate = this->track_.sampling_rate.value();
+        request.bit_depth = this->track_.bit_depth.value();
+        request.number_of_channels = this->track_.channels.value();
         if (!pipeline_->request_settings(request)) {
           esph_log_e(TAG, "Requested audio settings, didn't get accepted");
           pipeline_->on_settings_request_failed(request);
@@ -198,6 +199,10 @@ void HTTPStreamReaderAndDecoder::sdk_event_handler_(audio_event_iface_msg_t &msg
       request.sampling_rate = music_info.sample_rates;
       request.bit_depth = music_info.bits;
       request.number_of_channels = music_info.channels;
+      this->track_.sampling_rate = music_info.sample_rates;
+      this->track_.bit_depth = music_info.bits;
+      this->track_.channels = music_info.channels;
+
       if (!pipeline_->request_settings(request)) {
         esph_log_e(TAG, "Requested audio settings, didn't get accepted");
         pipeline_->on_settings_request_failed(request);

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -13,11 +13,34 @@ enum class ADFCodec : uint8_t {AAC = 0, AMR, FLAC, MP3, OGG, OPUS, WAV};
 
 class Track {
 public:
+  Track() = default;
+  Track(ADFCodec codec, int rate, int bits, int channels) :
+    codec(codec),
+    sampling_rate(rate),
+    bit_depth(bits),
+    channels(channels) {}
+
+  Track( int rate, int bits, int channels) :
+    codec(ADFCodec::MP3),
+    sampling_rate(rate),
+    bit_depth(bits),
+    channels(channels) {}
+
   std::string uri{""};
   optional<ADFCodec> codec;
   optional<int> sampling_rate;
   optional<int> bit_depth;
   optional<int> channels;
+
+  Track set_uri(std::string uri){ this->uri = uri; return *this; }
+
+  bool all_set(){ return (
+       codec.has_value()
+    && sampling_rate.has_value()
+    && bit_depth.has_value()
+    && channels.has_value()
+    );
+  }
 };
 
 
@@ -34,8 +57,7 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
   bool prepare_elements(bool initial_call) override;
   bool pause_elements(bool initial_call) override;
 
-  void set_track(Track track){}
-  void prepare_track(Track track){}
+  void set_track(Track track){ this->track_ = track; }
 
   void set_fixed_settings(bool value){ this->fixed_settings_ = value; }
 
@@ -50,6 +72,7 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
 
   bool fixed_settings_{false};
   bool audio_settings_reported_{false};
+  Track track_{};
 
   PipelineElementState desired_state_{PipelineElementState::UNINITIALIZED};
   std::string current_url_{"https://dl.espressif.com/dl/audio/ff-16b-2c-44100hz.mp3"};

--- a/esphome/components/adf_pipeline/adf_audio_sources.h
+++ b/esphome/components/adf_pipeline/adf_audio_sources.h
@@ -4,8 +4,22 @@
 
 #include "adf_audio_element.h"
 #include <raw_stream.h>
+#include "esphome/core/helpers.h"
+
 namespace esphome {
 namespace esp_adf {
+
+enum class ADFCodec : uint8_t {AAC = 0, AMR, FLAC, MP3, OGG, OPUS, WAV};
+
+class Track {
+public:
+  std::string uri{""};
+  optional<ADFCodec> codec;
+  optional<int> sampling_rate;
+  optional<int> bit_depth;
+  optional<int> channels;
+};
+
 
 class ADFPipelineSourceElement : public ADFPipelineElement {
  public:
@@ -20,6 +34,8 @@ class HTTPStreamReaderAndDecoder : public ADFPipelineSourceElement {
   bool prepare_elements(bool initial_call) override;
   bool pause_elements(bool initial_call) override;
 
+  void set_track(Track track){}
+  void prepare_track(Track track){}
 
   void set_fixed_settings(bool value){ this->fixed_settings_ = value; }
 

--- a/esphome/components/adf_pipeline/media_player/__init__.py
+++ b/esphome/components/adf_pipeline/media_player/__init__.py
@@ -3,7 +3,8 @@
 import esphome.codegen as cg
 from esphome.components import media_player
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_NUM_CHANNELS, CONF_ID, __version__ as ESPHOME_VERSION
+
 
 from .. import (
     esp_adf_ns,
@@ -20,16 +21,57 @@ ADFMediaPlayer = esp_adf_ns.class_(
     "ADFMediaPlayer", ADFPipelineController, media_player.MediaPlayer, cg.Component
 )
 
+
+ADFCodec = esp_adf_ns.enum("ADFCodec", is_class=True)
+CODECS = {"MP3": ADFCodec.MP3}
+
+CONF_BITS_PER_SAMPLE = "bits_per_sample"
+CONF_CODEC = "codec"
+CONF_SAMPLE_RATE = "sample_rate"
+CONF_ANNOUNCEMENT_AUDIO = "announcement_audio"
+
+FIXED_AUDIO_SETTINGS_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_CODEC, default="MP3"): cv.enum(CODECS),
+        cv.Required(CONF_SAMPLE_RATE): cv.int_range(min=1),
+        cv.Required(CONF_BITS_PER_SAMPLE): cv.int_range(min=1),
+        cv.Required(CONF_NUM_CHANNELS): cv.int_range(min=1),
+    }
+)
+
 CONFIG_SCHEMA = media_player.MEDIA_PLAYER_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(ADFMediaPlayer),
+        cv.Optional(CONF_ANNOUNCEMENT_AUDIO): FIXED_AUDIO_SETTINGS_SCHEMA,
     }
 ).extend(ADF_PIPELINE_CONTROLLER_SCHEMA)
+
+
+def check_version() -> bool:
+    version_parts = ESPHOME_VERSION.split(".")
+    if int(version_parts[0]) > 2024 or (
+        int(version_parts[0]) == 2024 and int(version_parts[1]) > 5
+    ):
+        return True
+    return False
 
 
 # @coroutine_with_priority(100.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    if check_version():
+        cg.add_define("MP_ANNOUNCE")
+        if CONF_ANNOUNCEMENT_AUDIO in config:
+            caa = config[CONF_ANNOUNCEMENT_AUDIO]
+            cg.add(
+                var.set_announce_base_track(
+                    caa[CONF_CODEC],
+                    caa[CONF_SAMPLE_RATE],
+                    caa[CONF_BITS_PER_SAMPLE],
+                    caa[CONF_NUM_CHANNELS],
+                )
+            )
+
     await cg.register_component(var, config)
     await setup_pipeline_controller(var, config)
     await media_player.register_media_player(var, config)

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
@@ -14,8 +14,11 @@ void ADFMediaPlayer::setup() {
 
 void ADFMediaPlayer::dump_config() {
   esph_log_config(TAG, "ESP-ADF-MediaPlayer:");
+#ifdef MP_ANNOUNCE
+  esph_log_config(TAG, "  MP_ANNOUNCE enabled");
+#endif
   int components = pipeline.get_number_of_elements();
-  esph_log_config(TAG, "  Number of ASPComponents: %d", components);
+  esph_log_config(TAG, "  Number of ADFComponents: %d", components);
 }
 
 void ADFMediaPlayer::set_stream_uri(const std::string& new_uri) {
@@ -31,37 +34,52 @@ void ADFMediaPlayer::set_announcement_uri(const std::string& new_uri) {
 
 void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
   if (call.get_media_url().has_value()) {
+    bool enqueue = false;
 #ifdef MP_ANNOUNCE
+    Track req_track;
     if (call.get_announcement().has_value()){
-      this->announcement_ =  call.get_announcement().value();
+      this->announcement_ = call.get_announcement().value();
     }
-    if( this->announcement_){
-      set_announcement_uri( call.get_media_url().value()) ;
-      //this->http_and_decoder_.set_fixed_settings(true);
+    if (this->announcement_){
+      req_track = this->announce_base_track_;
+      this->announce_track_ = req_track;
     }
     else
 #endif
     {
-      set_stream_uri( call.get_media_url().value()) ;
+      set_stream_uri(call.get_media_url().value()) ;
     }
-    esph_log_d(TAG, "Got control call in state %s", media_player_state_to_string(this->state) );
+    req_track.set_uri(call.get_media_url().value());
+
+    esph_log_d(TAG, "Got control call in state %s", media_player_state_to_string(this->state));
+    esph_log_d(TAG, "req_track stream uri: %s", req_track.uri.c_str() );
     switch(this->state){
       case media_player::MEDIA_PLAYER_STATE_IDLE:
 #ifdef MP_ANNOUNCE
-        this->http_and_decoder_.set_fixed_settings(this->announcement_);
+        this->http_and_decoder_.set_track(req_track);
+        this->set_current_track(req_track);
 #endif
         pipeline.start();
         return;
+
       case media_player::MEDIA_PLAYER_STATE_PAUSED:
       case media_player::MEDIA_PLAYER_STATE_PLAYING:
-        this->play_intent_ = true;
+        if (this->announcement_){
+          this->announce_track_ = req_track;
+        }
+        else{
+          this->set_next_track(req_track);
+        }
         pipeline.stop();
         return;
+
 #ifdef MP_ANNOUNCE
       case media_player::MEDIA_PLAYER_STATE_ANNOUNCING:
+        this->set_current_track(req_track);
         this->play_intent_ = true;
         return;
 #endif
+
       default:
         break;
     }
@@ -90,6 +108,7 @@ void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         }
         break;
       case media_player::MEDIA_PLAYER_COMMAND_STOP:
+        this->current_track_.reset();
         this->current_uri_.reset();
         pipeline.stop();
         this->http_and_decoder_.set_fixed_settings(false);
@@ -174,25 +193,26 @@ void ADFMediaPlayer::on_pipeline_state_change(PipelineState state) {
       {
         this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
         this->announcement_ = false;
-        if( this->current_uri_.has_value() )
+        this->announce_track_.reset();
+        if( this->current_track_.has_value() )
         {
-          this->http_and_decoder_.set_stream_uri(this->current_uri_.value());
-          this->http_and_decoder_.set_fixed_settings(false);
+          this->http_and_decoder_.set_track(this->current_track_.value());
           pipeline.restart();
         }
         else {
           publish_state();
         }
-        this->play_intent_ = false;
+      } else if (this->announce_track_.has_value()){
+        set_new_state(media_player::MEDIA_PLAYER_STATE_IDLE);
+        this->http_and_decoder_.set_track(this->announce_track_.value());
+        pipeline.restart();
       } else
 #endif
-      if (this->play_intent_) {
+      if (this->next_track_.has_value()){
         set_new_state(media_player::MEDIA_PLAYER_STATE_IDLE);
-        this->http_and_decoder_.set_fixed_settings(this->announcement_);
+        this->http_and_decoder_.set_track( this->next_track_.value() );
         pipeline.restart();
-        this->play_intent_ = false;
-      } else if (state == PipelineState::PAUSED)
-      {
+      } else if (state == PipelineState::PAUSED){
         if( set_new_state(media_player::MEDIA_PLAYER_STATE_PAUSED))
         {
           publish_state();

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.cpp
@@ -35,9 +35,9 @@ void ADFMediaPlayer::set_announcement_uri(const std::string& new_uri) {
 void ADFMediaPlayer::control(const media_player::MediaPlayerCall &call) {
   if (call.get_media_url().has_value()) {
     bool enqueue = false;
-#ifdef MP_ANNOUNCE
     Track req_track;
-    if (call.get_announcement().has_value()){
+#ifdef MP_ANNOUNCE
+  if (call.get_announcement().has_value()){
       this->announcement_ = call.get_announcement().value();
     }
     if (this->announcement_){

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -31,6 +31,9 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void set_stream_uri(const std::string& new_uri);
   void set_announcement_uri(const std::string& new_uri);
 
+  void set_announce_base_track(ADFCodec codec, int rate, int bits, int channels){
+    this->announce_base_track_ = Track(codec, rate, bits, channels);
+  }
   void set_current_track(const Track track){}
   void set_next_track(const Track track){}
 
@@ -61,6 +64,8 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   optional<std::string> current_uri_{};
   optional<std::string> announcement_uri_{};
 
+  Track announce_base_track_{};
+  optional<Track> announce_track_{};
   optional<Track> current_track_{};
   optional<Track> next_track_{};
 

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -34,8 +34,10 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   void set_announce_base_track(ADFCodec codec, int rate, int bits, int channels){
     this->announce_base_track_ = Track(codec, rate, bits, channels);
   }
-  void set_current_track(const Track track){}
-  void set_next_track(const Track track){}
+
+  void set_announce_track(const Track track){ this->announce_track_ = track; }
+  void set_current_track(const Track track){ this->current_track_ = track; }
+  void set_next_track(const Track track){ this->next_track_ = track; }
 
   void start() {pipeline.start();}
   void stop()  {pipeline.stop();}

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -10,6 +10,7 @@
 namespace esphome {
 namespace esp_adf {
 
+
 class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineController {
  public:
   // Pipeline implementations
@@ -29,6 +30,9 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   //
   void set_stream_uri(const std::string& new_uri);
   void set_announcement_uri(const std::string& new_uri);
+
+  void set_current_track(const Track track){}
+  void set_next_track(const Track track){}
 
   void start() {pipeline.start();}
   void stop()  {pipeline.stop();}
@@ -57,7 +61,14 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   optional<std::string> current_uri_{};
   optional<std::string> announcement_uri_{};
 
+  optional<Track> current_track_{};
+  optional<Track> next_track_{};
+
+  HTTPStreamReaderAndDecoder* curr_player_{};
+  HTTPStreamReaderAndDecoder* next_player_{};
+
   HTTPStreamReaderAndDecoder http_and_decoder_;
+  HTTPStreamReaderAndDecoder http_and_decoder_B_;
 };
 
 }  // namespace esp_adf

--- a/esphome/components/adf_pipeline/media_player/adf_media_player.h
+++ b/esphome/components/adf_pipeline/media_player/adf_media_player.h
@@ -73,7 +73,6 @@ class ADFMediaPlayer : public media_player::MediaPlayer, public ADFPipelineContr
   HTTPStreamReaderAndDecoder* next_player_{};
 
   HTTPStreamReaderAndDecoder http_and_decoder_;
-  HTTPStreamReaderAndDecoder http_and_decoder_B_;
 };
 
 }  // namespace esp_adf


### PR DESCRIPTION
Adds *announcement_audio* config to adf-media-player. 
If set, these settings are used when playing an announcement and the audio detecting phase can be skipped.