### PR TITLE
implement pipeline element register

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16.0)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(esphome_audio)

--- a/esphome/components/adf_pipeline/__init__.py
+++ b/esphome/components/adf_pipeline/__init__.py
@@ -4,8 +4,11 @@ import os
 
 from ._common import ( # noqa: F401
     esp_adf_ns,
-    ADFPipelineProcess,
     ADFPipelineElement,
+    ADFPipelineProcess,
+    ADFPipelineSink,
+    ADFPipelineSource,
+    ADFPipelineController,
     register_element,
     get_registered_element,
     validate_element,
@@ -55,18 +58,14 @@ async def setup_pipeline_controller(cntrl, config: dict) -> None:
 
     if CONF_ADF_PIPELINE in config:
         for comp_id in config[CONF_ADF_PIPELINE]:
-            if comp_id in SELF_DESCRIPTORS:
-                cg.add(cntrl.append_own_elements())
-            elif (type_ := get_registered_element(comp_id)):
-                element_id = ID(
-                    cv.validate_id_name(config[CONF_ID].id + "_"+comp_id),
-                    is_declaration=True,
-                    type=type_,
-                )
-                comp = cg.new_Pvariable(element_id)
-                cg.add(cntrl.add_element_to_pipeline(comp))
+            if isinstance(comp_id, str):
+                if comp_id in SELF_DESCRIPTORS:
+                    cg.add(cntrl.append_own_elements())
+            elif isinstance(comp_id, ID):
+                    comp = await cg.get_variable(comp_id)
+                    cg.add(cntrl.add_element_to_pipeline(comp))
             else:
-                comp = await cg.get_variable(comp_id)
+                comp = await get_registered_element(comp_id)
                 cg.add(cntrl.add_element_to_pipeline(comp))
 
 

--- a/esphome/components/adf_pipeline/_common.py
+++ b/esphome/components/adf_pipeline/_common.py
@@ -1,0 +1,24 @@
+from esphome.util import Registry
+import esphome.config_validation as cv
+import esphome.codegen as cg
+
+esp_adf_ns = cg.esphome_ns.namespace("esp_adf")
+
+ADFPipelineController = esp_adf_ns.class_("ADFPipelineController")
+
+ADFPipelineElement = esp_adf_ns.class_("ADFPipelineElement")
+ADFPipelineSink = esp_adf_ns.class_("ADFPipelineSinkElement", ADFPipelineElement)
+ADFPipelineSource = esp_adf_ns.class_("ADFPipelineSourceElement", ADFPipelineElement)
+ADFPipelineProcess = esp_adf_ns.class_("ADFPipelineProcessElement", ADFPipelineElement)
+
+def register_element(name, element_type, schema = {}):
+    return ELEMENT_REGISTRY.register(name, element_type, schema)
+
+ELEMENT_REGISTRY = Registry()
+validate_element = cv.validate_registry_entry("element", ELEMENT_REGISTRY)
+validate_element_list = cv.validate_registry("element", ELEMENT_REGISTRY)
+
+
+register_element("resampler", esp_adf_ns.class_("ADFResampler", ADFPipelineProcess, ADFPipelineElement))
+
+

--- a/esphome/components/adf_pipeline/_common.py
+++ b/esphome/components/adf_pipeline/_common.py
@@ -11,8 +11,14 @@ ADFPipelineSink = esp_adf_ns.class_("ADFPipelineSinkElement", ADFPipelineElement
 ADFPipelineSource = esp_adf_ns.class_("ADFPipelineSourceElement", ADFPipelineElement)
 ADFPipelineProcess = esp_adf_ns.class_("ADFPipelineProcessElement", ADFPipelineElement)
 
-def register_element(name, element_type, schema = {}):
-    return ELEMENT_REGISTRY.register(name, element_type, schema)
+def register_element(name, element_type):
+    return ELEMENT_REGISTRY.register(name, element_type, {})
+
+def get_registered_element (name):
+    element = ELEMENT_REGISTRY[name]
+    if element == None:
+        return None
+    return element.type_id
 
 ELEMENT_REGISTRY = Registry()
 validate_element = cv.validate_registry_entry("element", ELEMENT_REGISTRY)
@@ -20,5 +26,3 @@ validate_element_list = cv.validate_registry("element", ELEMENT_REGISTRY)
 
 
 register_element("resampler", esp_adf_ns.class_("ADFResampler", ADFPipelineProcess, ADFPipelineElement))
-
-

--- a/esphome/components/adf_pipeline/_common.py
+++ b/esphome/components/adf_pipeline/_common.py
@@ -1,6 +1,8 @@
 from esphome.util import Registry
 import esphome.config_validation as cv
 import esphome.codegen as cg
+from esphome.core import ID
+
 
 esp_adf_ns = cg.esphome_ns.namespace("esp_adf")
 
@@ -11,18 +13,35 @@ ADFPipelineSink = esp_adf_ns.class_("ADFPipelineSinkElement", ADFPipelineElement
 ADFPipelineSource = esp_adf_ns.class_("ADFPipelineSourceElement", ADFPipelineElement)
 ADFPipelineProcess = esp_adf_ns.class_("ADFPipelineProcessElement", ADFPipelineElement)
 
-def register_element(name, element_type):
-    return ELEMENT_REGISTRY.register(name, element_type, {})
 
-def get_registered_element (name):
-    element = ELEMENT_REGISTRY[name]
-    if element == None:
-        return None
-    return element.type_id
+def register_element(name, element_type, schema=None):
+    if schema is None:
+        schema = []
+    return ELEMENT_REGISTRY.register(name, element_type, schema)
+
+
+async def get_registered_element(conf):
+    return await cg.build_registry_entry(ELEMENT_REGISTRY, conf)
+
 
 ELEMENT_REGISTRY = Registry()
 validate_element = cv.validate_registry_entry("element", ELEMENT_REGISTRY)
 validate_element_list = cv.validate_registry("element", ELEMENT_REGISTRY)
 
 
-register_element("resampler", esp_adf_ns.class_("ADFResampler", ADFPipelineProcess, ADFPipelineElement))
+@register_element("resampler", esp_adf_ns.class_("ADFResampler", ADFPipelineProcess),{
+    cv.Optional("src_rate", default=16000): cv.int_,
+    cv.Optional("src_num_channels", default=2): cv.int_range(1,2),
+    cv.Optional("dst_rate", default=16000): cv.int_,
+    cv.Optional("dst_num_channels", default=2): cv.int_range(1,2),
+})
+def do_resampler(config, element_id):
+    cntrl = cg.new_Pvariable(element_id)
+    cg.add(cntrl.set_src_rate(config["src_rate"]))
+    cg.add(cntrl.set_src_num_channels(config["src_num_channels"]))
+
+    cg.add(cntrl.set_dst_rate(config["dst_rate"]))
+    cg.add(cntrl.set_dst_num_channels(config["dst_num_channels"]) )
+
+    return cntrl
+

--- a/esphome/components/adf_pipeline/adf_audio_process.h
+++ b/esphome/components/adf_pipeline/adf_audio_process.h
@@ -15,9 +15,14 @@ class ADFPipelineProcessElement : public ADFPipelineElement {
 class ADFResampler : public ADFPipelineProcessElement {
  public:
   const std::string get_name() override { return "Resampler"; }
+  void set_src_rate(int value) { this->src_rate_ = value; };
+  void set_dst_rate(int value) { this->dst_rate_ = value; };
+  void set_src_num_channels(int value) { this->src_num_channels_ = value; };
+  void set_dst_num_channels(int value) { this->dst_num_channels_ = value; };
 
  protected:
   bool init_adf_elements_() override;
+
   void on_settings_request(AudioPipelineSettingsRequest &request) override;
 
   int src_rate_{16000};


### PR DESCRIPTION
This PR allows to setup more pipeline processing components easier with the use of esphome's python registry class.