### PR TITLE
Make `external_component` url work

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This custom component includes:
 external_components:
   - source:
       type: git
-      url: https://github.com/gnumpi/esphome_audio
+      url: https://github.com/gnumpi/esphome_audio.git
       ref: main
     components: [ adf_pipeline, i2s_audio ]
 ```


### PR DESCRIPTION
There was `.git` missing